### PR TITLE
Preserve cookies in WebAuthenticators and better Redirect URL detection

### DIFF
--- a/src/Xamarin.Auth.iOS/WebAuthenticatorController.cs
+++ b/src/Xamarin.Auth.iOS/WebAuthenticatorController.cs
@@ -14,6 +14,7 @@
 //    limitations under the License.
 //
 using System;
+using System.Linq;
 using System.Threading.Tasks;
 using MonoTouch.UIKit;
 using MonoTouch.Foundation;
@@ -89,7 +90,7 @@ namespace Xamarin.Auth
 					//
 					// Delete cookies so we can work with multiple accounts
 					//
-					DeleteCookies (t.Result);
+					UpdateCookies (t.Result);
 					
 					//
 					// Begin displaying the page
@@ -99,15 +100,35 @@ namespace Xamarin.Auth
 			}, TaskScheduler.FromCurrentSynchronizationContext ());
 		}
 
-		void DeleteCookies (Uri url)
+		void UpdateCookies (Uri uri)
 		{
-			//
-			// Delete all cookies so that redirects have their cookies
-			// erased too.
-			//
+			if (authenticator.ExistingAccount != null) {
+				SetCookies (authenticator.ExistingAccount.Cookies, uri);
+			}
+			else {
+				ClearCookies (uri);
+			}
+		}
+
+		void SetCookies (System.Net.CookieContainer cookies, Uri uri)
+		{
 			var store = NSHttpCookieStorage.SharedStorage;
-			var cookies = store.Cookies;
-			foreach (var c in cookies) {
+			var nsurl = NSUrl.FromString(uri.AbsoluteUri);
+
+			var nscookies = from c in cookies.GetCookies (uri).OfType<System.Net.Cookie> ()
+				select new NSHttpCookie (c);
+
+			store.SetCookies (nscookies.ToArray (), nsurl, nsurl);
+		}
+
+		void ClearCookies (Uri uri)
+		{
+			var store = NSHttpCookieStorage.SharedStorage;
+			var nsurl = NSUrl.FromString(uri.AbsoluteUri);
+
+			var nscookies = store.CookiesForUrl (nsurl);
+
+			foreach (var c in nscookies) {
 				store.DeleteCookie (c);
 			}
 		}
@@ -189,19 +210,25 @@ namespace Xamarin.Auth
 				this.controller = controller;
 			}
 
+			public override bool ShouldStartLoad (UIWebView webView, NSUrlRequest request, UIWebViewNavigationType navigationType)
+			{
+				var nsUrl = request.Url;
+
+				if (nsUrl != null) {
+					Uri url;
+					if (Uri.TryCreate (nsUrl.AbsoluteString, UriKind.Absolute, out url)) {
+						controller.authenticator.OnPageLoading (url);
+					}
+				}
+
+				return true;
+			}
+
 			public override void LoadStarted (UIWebView webView)
 			{
 				controller.activity.StartAnimating ();
 
 				webView.UserInteractionEnabled = false;
-
-				var nsUrl = webView.Request.Url;
-				if (nsUrl != null) {
-					Uri url;
-					if (Uri.TryCreate (webView.Request.Url.AbsoluteString, UriKind.Absolute, out url)) {
-						controller.authenticator.OnPageLoading (url);
-					}
-				}
 			}
 
 			public override void LoadFailed (UIWebView webView, NSError error)

--- a/src/Xamarin.Auth/Authenticator.cs
+++ b/src/Xamarin.Auth/Authenticator.cs
@@ -45,6 +45,16 @@ namespace Xamarin.Auth
 		public string Title { get; set; }
 
 		/// <summary>
+		/// An existing account that this authenticator should use to prefill as much information as it can.
+		/// </summary>
+		public Account ExistingAccount { get; set; }
+
+		/// <summary>
+		/// Whether this authenticator has successfully completed authentication.
+		/// </summary>
+		public bool IsAuthenticated { get; private set; }
+
+		/// <summary>
 		/// Occurs when authentication has been successfully or unsuccessfully completed.
 		/// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
 		/// authentication was successful.
@@ -52,7 +62,7 @@ namespace Xamarin.Auth
 		public event EventHandler<AuthenticatorCompletedEventArgs> Completed;
 
 		/// <summary>
-		/// Occurs when there an error is encountered when authenticating.
+		/// Occurs when an error is encountered during authentication.
 		/// </summary>
 		public event EventHandler<AuthenticatorErrorEventArgs> Error;
 
@@ -101,6 +111,7 @@ namespace Xamarin.Auth
 		/// </param>
 		public void OnSucceeded (Account account)
 		{
+			IsAuthenticated = true;
 			BeginInvokeOnUIThread (delegate {
 				var ev = Completed;
 				if (ev != null) {

--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -206,7 +206,7 @@ namespace Xamarin.Auth
 		/// <param name='fragment'>
 		/// The parsed fragment of the URL.
 		/// </param>
-		protected override void OnPageLoaded (Uri url, IDictionary<string, string> query, IDictionary<string, string> fragment)
+		protected override void OnPageEncountered (Uri url, IDictionary<string, string> query, IDictionary<string, string> fragment)
 		{
 			var all = new Dictionary<string, string> (query);
 			foreach (var kv in fragment)
@@ -226,7 +226,7 @@ namespace Xamarin.Auth
 			//
 			// Continue processing
 			//
-			base.OnPageLoaded (url, query, fragment);
+			base.OnPageEncountered (url, query, fragment);
 		}
 
 		/// <summary>

--- a/src/Xamarin.Auth/WebRedirectAuthenticator.cs
+++ b/src/Xamarin.Auth/WebRedirectAuthenticator.cs
@@ -70,12 +70,7 @@ namespace Xamarin.Auth
 			var query = WebEx.FormDecode (url.Query);
 			var fragment = WebEx.FormDecode (url.Fragment);
 
-			OnPageLoaded (url, query, fragment);
-		}
-
-		private bool UrlMatchesRedirect (Uri url)
-		{
-			return url.Host == redirectUrl.Host && url.LocalPath == redirectUrl.LocalPath;
+			OnPageEncountered (url, query, fragment);
 		}
 
 		/// <summary>
@@ -86,9 +81,10 @@ namespace Xamarin.Auth
 		/// </param>
 		public override void OnPageLoading (Uri url)
 		{
-			if (UrlMatchesRedirect (url)) {
-				OnBrowsingCompleted ();
-			}
+			var query = WebEx.FormDecode (url.Query);
+			var fragment = WebEx.FormDecode (url.Fragment);
+
+			OnPageEncountered (url, query, fragment);
 		}
 
 		/// <summary>
@@ -103,7 +99,7 @@ namespace Xamarin.Auth
 		/// <param name='fragment'>
 		/// The parsed fragment of the URL.
 		/// </param>
-		protected virtual void OnPageLoaded (Uri url, IDictionary<string, string> query, IDictionary<string, string> fragment)
+		protected virtual void OnPageEncountered (Uri url, IDictionary<string, string> query, IDictionary<string, string> fragment)
 		{
 			var all = new Dictionary<string, string> (query);
 			foreach (var kv in fragment)
@@ -124,9 +120,14 @@ namespace Xamarin.Auth
 			//
 			// Watch for the redirect
 			//
-			if (UrlMatchesRedirect (url)) {
+			if (UrlMatchesRedirect (url) && !IsAuthenticated) {
 				OnRedirectPageLoaded (url, query, fragment);
 			}
+		}
+
+		private bool UrlMatchesRedirect (Uri url)
+		{
+			return url.Host == redirectUrl.Host && url.LocalPath == redirectUrl.LocalPath;
 		}
 
 		/// <summary>


### PR DESCRIPTION
Added ability to preserve cookies when using a WebAuthenticator by specifying an ExistingAccount object. This is to make re-authentication scenarios on single-account apps better for the user.

Also, added logic to detect redirects early than before so that web success screens should be hidden. This fixes the bug of seeing those ugly white Facebook success screens.

Sorry, this should have been two commits, but the work got entwined with each other.
