### PR TITLE
Use TaskCompletionSource instead of Task.Factory.StartNew where simple result is needed

### DIFF
--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -189,9 +189,9 @@ namespace Xamarin.Auth
 				Uri.EscapeDataString (scope),
 				Uri.EscapeDataString (requestState)));
 
-			return Task.Factory.StartNew (() => {
-				return url;
-			});
+			var tcs = new TaskCompletionSource<Uri> ();
+			tcs.SetResult (url);
+			return tcs.Task;
 		}
 
 		/// <summary>

--- a/src/Xamarin.Auth/WebRedirectAuthenticator.cs
+++ b/src/Xamarin.Auth/WebRedirectAuthenticator.cs
@@ -54,9 +54,11 @@ namespace Xamarin.Auth
 		/// <returns>
 		/// A task that will return the initial URL.
 		/// </returns>
-		public override System.Threading.Tasks.Task<Uri> GetInitialUrlAsync ()
+		public override Task<Uri> GetInitialUrlAsync ()
 		{
-			return Task.Factory.StartNew (() => initialUrl);
+			var tcs = new TaskCompletionSource<Uri> ();
+			tcs.SetResult (initialUrl);
+			return tcs.Task;
 		}
 
 		/// <summary>


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

Hey, this is a very minor fix, but it's wasteful to spin off tasks just to return values.
We can use TaskCompletionSource instead.
