### PR TITLE
Preserve synchronization context because OnRetrievedAccountProperties uses it

### DIFF
--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -263,7 +263,7 @@ namespace Xamarin.Auth
 						} else {
 							OnRetrievedAccountProperties (task.Result);
 						}
-					});
+					}, TaskScheduler.FromCurrentSynchronizationContext ());
 				} else {
 					OnError ("Expected code in response, but did not receive one.");
 					return;


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

`OnRetrievedAccountProperties` tries to pass along a synchronization context:

```
if (getUsernameAsync != null) {
    getUsernameAsync (accountProperties).ContinueWith (task => {
        // ...
    }, TaskScheduler.FromCurrentSynchronizationContext ());
```

However, `OnRetrievedAccountProperties` is also called from a continuation inside `OnRedirectPageLoaded` that doesn't preserve the context:

```
RequestAccessTokenAsync (code).ContinueWith (task => {
    if (task.IsFaulted) {
        OnError (task.Exception);
    } else {
        // Ouch!
        OnRetrievedAccountProperties (task.Result); 
    }
});
```

This pull requests adds `TaskScheduler.FromCurrentSynchronizationContext ()` to this continuation so the code doesn't crash.
