### PR TITLE
Propagate GetAccessTokenAsync exceptions to the calling code

### DIFF
--- a/src/Xamarin.Auth/OAuth1Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth1Authenticator.cs
@@ -163,7 +163,13 @@ namespace Xamarin.Auth
 
 				r.TryGetValue ("oauth_verifier", out verifier);
 
-				GetAccessTokenAsync ();
+				GetAccessTokenAsync ().ContinueWith (getTokenTask => {
+					if (getTokenTask.IsCanceled) {
+						OnCancelled ();
+					} else if (getTokenTask.IsFaulted) {
+						OnError (getTokenTask.Exception);
+					}
+				}, TaskContinuationOptions.NotOnRanToCompletion);
 			}
 		}
 


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

Right now exceptions from `GetAccessTokenAsync` are unobserved.
Shouldn't they propagate to the calling code?
