### PR TITLE
Support parsing access token from JSON as needed by Google and Foursquare

### DIFF
--- a/src/Xamarin.Auth.Android/Xamarin.Auth.Android.csproj
+++ b/src/Xamarin.Auth.Android/Xamarin.Auth.Android.csproj
@@ -39,6 +39,7 @@
     <Reference Include="System" />
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Json" />
     <Reference Include="Mono.Android" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />

--- a/src/Xamarin.Auth.iOS/Xamarin.Auth.iOS.csproj
+++ b/src/Xamarin.Auth.iOS/Xamarin.Auth.iOS.csproj
@@ -36,6 +36,7 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="monotouch" />
+    <Reference Include="System.Json" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Resources\" />

--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -306,7 +306,8 @@ namespace Xamarin.Auth
 			}
 			return req.GetResponseAsync ().ContinueWith (task => {
 				var text = task.Result.GetResponseText ();
-				var data = WebEx.FormDecode (text);
+				var data = text.Contains ("{") ? WebEx.JsonDecode (text) : WebEx.FormDecode (text);
+
 				if (data.ContainsKey ("error")) {
 					throw new AuthException ("Error authenticating: " + data ["error"]);
 				} else if (data.ContainsKey ("access_token")) {

--- a/src/Xamarin.Auth/WebEx.cs
+++ b/src/Xamarin.Auth/WebEx.cs
@@ -19,6 +19,7 @@ using System.Threading.Tasks;
 using System.Collections.Generic;
 using System.Text;
 using System.IO;
+using System.Json;
 using System.Linq;
 using System.Globalization;
 
@@ -167,6 +168,28 @@ namespace Xamarin.Utilities
 			}
 
 			return sb.ToString();
+		}
+
+		public static Dictionary<string, string> JsonDecode (string encoded)
+		{
+			var inputs = new Dictionary<string, string> ();
+			var json = JsonValue.Parse (encoded) as JsonObject;
+
+			foreach (var kv in json) {
+				var v = kv.Value as JsonValue;
+				if (v != null) {
+					switch (v.JsonType) {
+					case JsonType.String:
+						inputs [kv.Key] = (string) v;
+						break;
+					case JsonType.Number:
+						inputs [kv.Key] = ((int) v).ToString ();
+						break;
+					}
+				}
+			}
+
+			return inputs;
 		}
 	}
 }


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

This pull request implements #18 and is mostly @praeclarum's code, but with a minor tweak: Google will send `expires_in` as an integer, so we need to support `int`s when parsing JSON.
