### PR TITLE
Make request body configurable for service implementors and accessible from outside

### DIFF
--- a/src/Xamarin.Auth/Request.cs
+++ b/src/Xamarin.Auth/Request.cs
@@ -50,10 +50,16 @@ namespace Xamarin.Auth
 
 		/// <summary>
 		/// The parameters of the request. These will be added to the query string of the
-		/// URL for GET requests, encoded as form a parameters for POSTs, and added as
-		/// multipart values if the request uses <see cref="Multiparts"/>.
+		/// URL for GET requests, encoded as form parameters and concatenated with <see cref="Body"/> for POSTs,
+		/// and added as multipart values if the request uses <see cref="Multiparts"/>.
 		/// </summary>
 		public IDictionary<string, string> Parameters { get; protected set; }
+
+		/// <summary>
+		/// The body of the request. Unless <see cref="HasBody"/> is overriden,
+		/// its value will be appended to the form-encoded <see cref="Parameters"/> for POSTs.
+		/// </summary>
+		public virtual string Body { get; set; }
 
 		/// <summary>
 		/// The account that will be used to authenticate this request.
@@ -216,8 +222,8 @@ namespace Xamarin.Auth
 						return new Response ((HttpWebResponse)resTask.Result);
 					}, cancellationToken);
 				}, cancellationToken).Unwrap();
-			} else if (Method == "POST" && Parameters.Count > 0) {
-				var body = Parameters.FormEncode ();
+			} else if (Method == "POST" && HasBody) {
+				var body = GetRawBody ();
 				var bodyData = System.Text.Encoding.UTF8.GetBytes (body);
 				request.ContentLength = bodyData.Length;
 				request.ContentType = "application/x-www-form-urlencoded";
@@ -348,6 +354,24 @@ namespace Xamarin.Auth
 			}
 
 			return request;
+		}
+
+		/// <summary>
+		/// Gets a value indicating whether this <see cref="Xamarin.Auth.Request"/> needs to have a body on POST.
+		/// </summary>
+		protected virtual bool HasBody {
+			get {
+				return Parameters.Count > 0 || !string.IsNullOrWhiteSpace (Body);
+			}
+		}
+
+		/// <summary>
+		/// Returns the request body that will be used for POST if <see cref="HasBody"/> is <c>true</c>.
+		/// By default, it includes form-encoded <see cref="Parameters"/> concatenated with <see cref="Body"/>.
+		/// </summary>
+		public virtual string GetRawBody ()
+		{
+			return Parameters.FormEncode () + Body;
 		}
 	}
 }


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

We're using this to implement Facebook batch requests.
This is roughly how we use it:

```
    public Request CreateBatchRequest (params Request [] requests)
    {
        var session = EnsureLoggedIn ();
        JArray jsonRequests = new JArray ();

        foreach (var request in requests) {
            var jsonRequest = new JObject {
                {"method", request.Method},
                {"relative_url", BaseUri.MakeRelativeUri (request.Url).ToString ()}
            };

            var body = request.GetRawBody (); // HERE
            if (body.Length > 0) 
                jsonRequest ["body"] = body;

            jsonRequests.Add (jsonRequest);
        }

        var batchRequest = session.Service.CreateRequest ("POST", BaseUri, session.Account);
        batchRequest.Body = "batch=" + jsonRequests.ToString (); // AND HERE

        return batchRequest;
    }
```

Docs on batch requests:

https://developers.facebook.com/docs/reference/api/batch/

We didn't want to subclass `Request` and opted for keeping `Body` public because we want to make it **implementation-independent**, i.e. both `FacebookService` and `Facebook6Service` (that uses iOS 6 Social.framework) can be used with this code.
