### PR TITLE
Expose RequestAccessTokenAsync down the hierarchy

### DIFF
--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -283,7 +283,7 @@ namespace Xamarin.Auth
 		/// <param name='code'>
 		/// Code.
 		/// </param>
-		Task<Dictionary<string,string>> RequestAccessTokenAsync (string code)
+		Task<IDictionary<string,string>> RequestAccessTokenAsync (string code)
 		{
 			var queryValues = new Dictionary<string, string> {
 				{ "grant_type", "authorization_code" },
@@ -294,6 +294,12 @@ namespace Xamarin.Auth
 			if (!string.IsNullOrEmpty (clientSecret)) {
 				queryValues ["client_secret"] = clientSecret;
 			}
+
+			return RequestAccessTokenAsync (queryValues);
+		}
+
+		protected Task<IDictionary<string,string>> RequestAccessTokenAsync (IDictionary<string, string> queryValues)
+		{
 			var query = queryValues.FormEncode ();
 
 			var req = WebRequest.Create (accessTokenUrl);

--- a/src/Xamarin.Auth/WebEx.cs
+++ b/src/Xamarin.Auth/WebEx.cs
@@ -111,7 +111,7 @@ namespace Xamarin.Utilities
 		static char[] AmpersandChars = new char[] { '&' };
 		static char[] EqualsChars = new char[] { '=' };
 
-		public static Dictionary<string, string> FormDecode (string encodedString)
+		public static IDictionary<string, string> FormDecode (string encodedString)
 		{
 			var inputs = new Dictionary<string, string> ();
 


### PR DESCRIPTION
(This pull request is submitted under MIT/X11)

We use it to refresh access tokens for Google:

```
    class GoogleAuthenticator : OAuth2Authenticator {
        private string clientId, clientSecret;

        public Task<IDictionary<string, string>> RefreshAccessTokenAsync (string refreshToken)
        {
            return base.RequestAccessTokenAsync (new Dictionary<string, string> {
                { "grant_type", "refresh_token" },
                { "client_id", clientId },
                { "client_secret", clientSecret },
                { "refresh_token", refreshToken }
            });
        }

        public GoogleAuthenticator (string clientId, string clientSecret, string scope, Uri authorizeUrl, Uri redirectUrl, Uri accessTokenUrl, GetUsernameAsyncFunc getUsernameAsync)
            : base (clientId, clientSecret, scope, authorizeUrl, redirectUrl, accessTokenUrl, getUsernameAsync)
        {
            this.clientId = clientId;
            this.clientSecret = clientSecret;
        }
    }
```

It would also be convenient if `clientId` and `clientSecret` could be made `protected`, but that's not a big deal obviously.

It could make sense to move `RefreshAccessTokenAsync` down the hierarchy, but so far I've only seen Google use it, so I'm not sure.
