### PR TITLE
Make OAuth 1 header generation overridable

### DIFF
--- a/src/Xamarin.Auth/OAuth1Request.cs
+++ b/src/Xamarin.Auth/OAuth1Request.cs
@@ -78,6 +78,21 @@ namespace Xamarin.Auth
 			var req = GetPreparedWebRequest ();
 
 			//
+			// Authorize it
+			//
+			var authorization = GetAuthorizationHeader ();
+
+			req.Headers [HttpRequestHeader.Authorization] = authorization;
+
+			return base.GetResponseAsync (cancellationToken);
+		}
+
+		/// <summary>
+		/// Gets OAuth authorization header.
+		/// </summary>
+		protected virtual string GetAuthorizationHeader ()
+		{
+			//
 			// Make sure that the parameters array contains
 			// mulitpart keys if we're dealing with a buggy
 			// OAuth implementation (I'm looking at you Flickr).
@@ -93,10 +108,7 @@ namespace Xamarin.Auth
 				}
 			}
 
-			//
-			// Authorize it
-			//
-			var authorization = OAuth1.GetAuthorizationHeader (
+			return OAuth1.GetAuthorizationHeader (
 				Method,
 				Url,
 				ps,
@@ -104,10 +116,6 @@ namespace Xamarin.Auth
 				Account.Properties ["oauth_consumer_secret"],
 				Account.Properties ["oauth_token"],
 				Account.Properties ["oauth_token_secret"]);
-			
-			req.Headers [HttpRequestHeader.Authorization] = authorization;
-			
-			return base.GetResponseAsync (cancellationToken);
 		}
 	}
 }


### PR DESCRIPTION
(Licensed under MIT/X11)

Basically, we needed to extract `GetAuthorizationHeader` and make it `virtual` to implement Twitter Reverse Auth:

```
class ReverseAuthRequest : OAuth1Request {
    private string consumerKey;
    private string consumerSecret;

    public ReverseAuthRequest (Account account, string consumerKey, string consumerSecret)
        : base (
            "GET",
            new Uri ("https://api.twitter.com/oauth/request_token"),
            new Dictionary<string, string> { { "x_auth_mode", "reverse_auth" } },
            account
        )
    {
        this.consumerKey = consumerKey;
        this.consumerSecret = consumerSecret;
    }

    protected override string GetAuthorizationHeader ()
    {
        return OAuth1.GetAuthorizationHeader (
            Method,
            Url,
            new Dictionary<string, string> (Parameters),
            this.consumerKey,
            this.consumerSecret,
            string.Empty,
            string.Empty
        );
    }
}
```

https://dev.twitter.com/docs/ios/using-reverse-auth

Reverse Auth is essential if you're using Twitter.framework or Social.framework and want to verify account on server before signing the user in.
