### PR TITLE
Implement authorization using system browser (e.g. Safari)

### DIFF
--- a/src/Xamarin.Auth.Android/Xamarin.Auth.Android.csproj
+++ b/src/Xamarin.Auth.Android/Xamarin.Auth.Android.csproj
@@ -99,5 +99,8 @@
     <Compile Include="..\Xamarin.Auth\Response.cs">
       <Link>Response.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Auth\ICustomUrlHandler.cs">
+      <Link>ICustomUrlHandler.cs</Link>
+    </Compile>
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Auth.iOS/SafariUrlHandler.cs
+++ b/src/Xamarin.Auth.iOS/SafariUrlHandler.cs
@@ -1,0 +1,118 @@
+//
+//  Copyright 2013, Stampsy Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Threading.Tasks;
+using MonoTouch.Foundation;
+using MonoTouch.UIKit;
+
+namespace Xamarin.Auth
+{
+	/// <summary>
+	/// Implements custom URL handler for iOS.
+	/// Call <see cref="Instance"/>'s <see cref="HandleOpenUrl"/> and <see cref="WillEnterForeground"/> methods from respective <c>AppDelegate</c> methods in your iOS application.
+	/// </summary>
+	/// </summary>
+#if XAMARIN_AUTH_INTERNAL
+	internal class SafariUrlHandler : ICustomUrlHandler
+#else
+	public class SafariUrlHandler : ICustomUrlHandler
+#endif
+	{
+		static readonly Lazy<SafariUrlHandler> instance = new Lazy<SafariUrlHandler> (() => new SafariUrlHandler ());
+
+		public static SafariUrlHandler Instance {
+			get { return instance.Value; }
+		}
+
+
+		TaskCompletionSource<Uri> tcs;
+		string callbackScheme;
+
+		private SafariUrlHandler ()
+		{
+		}
+
+		/// <summary>
+		/// Opens <paramref name="url"/> in Safari and waits for user to return to the app.
+		/// 
+		/// If the user returns to the app by opening custom URL that starts from <paramref name="callbackScheme"/> from browser,
+		/// this custom URL will be the result of the task.
+		/// 
+		/// If custom URL doesn't match <paramref name="callbackScheme"/>, or if the app went foreground
+		/// without receiving a custom URL, the task will be cancelled.
+		/// </summary>
+		/// <remarks>
+		/// You need to call <see cref="HandleOpenUrl"/> and <see cref="WillEnterForeground"/> on this instance
+		/// from your <c>AppDelegate</c>'s respective methods.
+		/// </remarks>
+		public Task<Uri> OpenUrl (Uri url, string callbackScheme)
+		{
+			var tcs = new TaskCompletionSource<Uri> ();
+
+			UIApplication.SharedApplication.BeginInvokeOnMainThread (() => {
+				CancelTask ();
+
+				this.tcs = tcs;
+				this.callbackScheme = callbackScheme;
+
+				UIApplication.SharedApplication.OpenUrl (new NSUrl (url.ToString ()));
+			});
+
+			return tcs.Task;
+		}
+
+		void CancelTask ()
+		{
+			if (this.tcs != null)
+				this.tcs.TrySetCanceled ();
+
+			this.tcs = null;
+			this.callbackScheme = null;
+		}
+
+		/// <summary>
+		/// This method needs to be called from <c>AppDelegate.HandleOpenUrl</c>.
+		/// </summary>
+		public bool HandleOpenUrl (Uri url)
+		{
+			if (url.Scheme != callbackScheme)
+				return false;
+
+			if (this.tcs != null)
+				this.tcs.TrySetResult (url);
+
+			return true;
+		}
+
+		/// <summary>
+		/// This method needs to be called from <c>AppDelegate.WillEnterForeground.</c>
+		/// </summary>
+		public void WillEnterForeground ()
+		{
+			UIApplication.SharedApplication.BeginInvokeOnMainThread (() => {
+				// By the time we get here, if there has been no HandleOpenUrl call, consider it cancelled
+				CancelTask ();
+			});
+		}
+	}
+}

--- a/src/Xamarin.Auth.iOS/Xamarin.Auth.iOS.csproj
+++ b/src/Xamarin.Auth.iOS/Xamarin.Auth.iOS.csproj
@@ -99,5 +99,9 @@
     <Compile Include="..\Xamarin.Auth\Response.cs">
       <Link>Response.cs</Link>
     </Compile>
+    <Compile Include="..\Xamarin.Auth\ICustomUrlHandler.cs">
+      <Link>ICustomUrlHandler.cs</Link>
+    </Compile>
+    <Compile Include="SafariUrlHandler.cs" />
   </ItemGroup>
 </Project>

--- a/src/Xamarin.Auth/ICustomUrlHandler.cs
+++ b/src/Xamarin.Auth/ICustomUrlHandler.cs
@@ -1,0 +1,49 @@
+//
+//  Copyright 2013, Stampsy Ltd.
+//
+// Permission is hereby granted, free of charge, to any person obtaining
+// a copy of this software and associated documentation files (the
+// "Software"), to deal in the Software without restriction, including
+// without limitation the rights to use, copy, modify, merge, publish,
+// distribute, sublicense, and/or sell copies of the Software, and to
+// permit persons to whom the Software is furnished to do so, subject to
+// the following conditions:
+// 
+// The above copyright notice and this permission notice shall be
+// included in all copies or substantial portions of the Software.
+// 
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+// EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+// MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+// NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+// LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+// OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+// WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+//
+using System;
+using System.Threading.Tasks;
+
+namespace Xamarin.Auth
+{
+	/// <summary>
+	/// Represents a manager that can open a URL in system browser and then wait for user to return to the app.
+	/// </summary>
+#if XAMARIN_AUTH_INTERNAL
+	internal interface ICustomUrlHandler
+#else
+	public interface ICustomUrlHandler
+#endif
+	{
+		/// <summary>
+		/// Opens <paramref name="url"/> in system browser and waits for user to return to the app.
+		/// 
+		/// If the user returns to the app by opening custom URL that starts from <paramref name="callbackScheme"/> from browser,
+		/// this custom URL will be the result of the task.
+		/// 
+		/// If custom URL doesn't match <paramref name="callbackScheme"/>, or if the app went foreground
+		/// without receiving a custom URL, the task will be cancelled.
+		/// </summary>
+		Task<Uri> OpenUrl (Uri url, string callbackScheme);
+	}
+}
+

--- a/src/Xamarin.Auth/OAuth1Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth1Authenticator.cs
@@ -55,6 +55,10 @@ namespace Xamarin.Auth
 
 		string verifier;
 
+		protected override Uri CustomUrl {
+			get { return callbackUrl; }
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Xamarin.Auth.OAuth1Authenticator"/> class.
 		/// </summary>

--- a/src/Xamarin.Auth/WebRedirectAuthenticator.cs
+++ b/src/Xamarin.Auth/WebRedirectAuthenticator.cs
@@ -33,6 +33,10 @@ namespace Xamarin.Auth
 		Uri initialUrl;
 		Uri redirectUrl;
 
+		protected override Uri CustomUrl {
+			get { return redirectUrl; }
+		}
+
 		/// <summary>
 		/// Initializes a new instance of the <see cref="Xamarin.Auth.WebRedirectAuthenticator"/> class.
 		/// </summary>

--- a/src/Xamarin.Auth/Xamarin.Auth.csproj
+++ b/src/Xamarin.Auth/Xamarin.Auth.csproj
@@ -54,6 +54,7 @@
     <Compile Include="OAuth2Request.cs" />
     <Compile Include="Request.cs" />
     <Compile Include="Response.cs" />
+    <Compile Include="ICustomUrlHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
 </Project>


### PR DESCRIPTION
This commit adds support for authentication via system browser instead of presenting a modal view controller. It includes a working iOS implementation called `SafariUrlHandler`. Android clients [can implement](http://stackoverflow.com/a/2448531/458193) `ICustomUrlHandler` in their code.

Rationale: we noticed that a lot of people are already logged into Twitter/Facebook in Safari but don't remember / care to enter their passwords when presented with a modal form.

By using this method, we can just take them to Safari, where they are logged in, and then take them back into the app, while reusing `WebRedirectAuthenticator` logic.

![](http://i.imgur.com/zsD62hW.png)

We have a corresponding update for Xamarin.Social (not yet ready as a pull request) that uses this method:

``` c#
    /// <summary>
    /// Attempts to authenticate user with this service using the web browser.
    /// </summary>
    public virtual Task<IEnumerable<Account>> GetAccountsAsync (ICustomUrlHandler customUrlHandler)
    {
        if (customUrlHandler == null)
            throw new ArgumentNullException ("customUrlHandler", "This overload needs a system handler to launch browser and wait for redirect. " +
                "On iOS, you can use SafariUrlHandler.Instance, given that you call " +
                "its HandleOpenUrl and OnWentForeground methods from your AppDelegate.\n" +
                                    "On Android, you will need to supply your own implementation.");

        var tcs = new TaskCompletionSource<IEnumerable<Account>> ();

        var authenticator = GetAuthenticator () as WebAuthenticator;
        if (authenticator == null)
            throw new NotSupportedException ("This service does not support authentication via web browser.");

        authenticator.Completed += (sender, e) => {
            if (e.IsAuthenticated) {
                AccountStore.Create ().Save (e.Account, this.ServiceId);
                tcs.SetResult (new [] { e.Account });
            } else {
                tcs.SetException (new UnauthorizedAccessException ("Authentication failed."));
            }
        };

        authenticator.AuthenticateWithBrowser (customUrlHandler);
        return tcs.Task;
    }
```

So if you want to log into Twitter with Safari (on iOS), you add this to your `AppDelegate`:

``` c#
        public override bool OpenUrl (UIApplication application, NSUrl url, string sourceApplication, NSObject annotation)
        {
            return SafariUrlHandler.Instance.HandleOpenUrl (new Uri (url.AbsoluteString));
        }

        public override void WillEnterForeground (UIApplication application)
        {
            SafariUrlHandler.Instance.WillEnterForeground ();
        }
```

Calling

``` c#
    twitterService.GetAccountsAsync (SafariUrlHandler.Instance).ContinueWith (...)
```

will open Safari for you and log you in.

Code in this pull request is licensed under MIT/X11.
