### PR TITLE
Add GetValueFromJson to WebEx

### DIFF
--- a/src/Xamarin.Auth/WebEx.cs
+++ b/src/Xamarin.Auth/WebEx.cs
@@ -168,6 +168,22 @@ namespace Xamarin.Utilities
 
 			return sb.ToString();
 		}
+
+		public static string GetValueFromJson (string json, string key)
+		{
+		    var p = json.IndexOf ("\"" + key + "\"");
+		    if (p < 0) return "";
+		    var c = json.IndexOf (":", p);
+		    if (c < 0) return "";
+		    var q = json.IndexOf ("\"", c);
+		    if (q < 0) return "";
+		    var b = q + 1;
+		    var e = b;
+		    for (; e < json.Length && json[e] != '\"'; e++) {
+		    }
+		    var r = json.Substring (b, e - b);
+		    return r;
+		}
 	}
 }
 


### PR DESCRIPTION
This function was previously defined in FacebookService inside Xamarin.Social,
but we also needed it for implementing GoogleService, so it makes sense
to make it available as a help method in WebEx, which is shared by both Auth and Social.

Commit licensed under MIT/X11
