### PR TITLE
Adding ability to block the cancelling of an authentication flow

### DIFF
--- a/samples/Xamarin.Auth.Sample.Android/MainActivity.cs
+++ b/samples/Xamarin.Auth.Sample.Android/MainActivity.cs
@@ -10,13 +10,15 @@ namespace Xamarin.Auth.Sample.Android
 	[Activity (Label = "Xamarin.Auth Sample (Android)", MainLauncher = true)]
 	public class MainActivity : Activity
 	{
-		void LoginToFacebook (object sender, EventArgs e)
+		void LoginToFacebook (bool allowCancel)
 		{
 			var auth = new OAuth2Authenticator (
 				clientId: "App ID from https://developers.facebook.com/apps",
 				scope: "",
 				authorizeUrl: new Uri ("https://m.facebook.com/dialog/oauth/"),
 				redirectUrl: new Uri ("http://www.facebook.com/connect/login_success.html"));
+
+			auth.AllowCancel = allowCancel;
 
 			// If authorization succeeds or is canceled, .Completed will be fired.
 			auth.Completed += (s, ee) => {
@@ -54,7 +56,10 @@ namespace Xamarin.Auth.Sample.Android
 
 			this.facebookStatus = FindViewById<TextView> (Resource.Id.FacebookTextView);
 			var facebook = FindViewById<Button> (Resource.Id.FacebookButton);			
-			facebook.Click += LoginToFacebook;
+			facebook.Click += delegate { LoginToFacebook(true);};
+
+			var facebookNoCancel = FindViewById<Button> (Resource.Id.FacebookButtonNoCancel);
+			facebookNoCancel.Click += delegate { LoginToFacebook(false);};
 		}
 	}
 }

--- a/samples/Xamarin.Auth.Sample.Android/Resources/Resource.designer.cs
+++ b/samples/Xamarin.Auth.Sample.Android/Resources/Resource.designer.cs
@@ -64,7 +64,10 @@ namespace Xamarin.Auth.Sample.Android
 			public const int FacebookButton = 2131034112;
 			
 			// aapt resource value: 0x7f050001
-			public const int FacebookTextView = 2131034113;
+			public const int FacebookButtonNoCancel = 2131034113;
+			
+			// aapt resource value: 0x7f050002
+			public const int FacebookTextView = 2131034114;
 			
 			static Id()
 			{
@@ -97,6 +100,9 @@ namespace Xamarin.Auth.Sample.Android
 			
 			// aapt resource value: 0x7f040001
 			public const int Facebook = 2130968577;
+			
+			// aapt resource value: 0x7f040002
+			public const int FacebookNoCancel = 2130968578;
 			
 			// aapt resource value: 0x7f040000
 			public const int app_name = 2130968576;

--- a/samples/Xamarin.Auth.Sample.Android/Resources/layout/Main.axml
+++ b/samples/Xamarin.Auth.Sample.Android/Resources/layout/Main.axml
@@ -8,6 +8,11 @@
         android:layout_width="fill_parent"
         android:layout_height="wrap_content"
         android:text="@string/Facebook" />
+    <Button
+        android:text="@string/FacebookNoCancel"
+        android:layout_width="fill_parent"
+        android:layout_height="wrap_content"
+        android:id="@+id/FacebookButtonNoCancel" />
     <TextView
         android:textAppearance="?android:attr/textAppearanceMedium"
         android:layout_width="fill_parent"

--- a/samples/Xamarin.Auth.Sample.Android/Resources/values/Strings.xml
+++ b/samples/Xamarin.Auth.Sample.Android/Resources/values/Strings.xml
@@ -2,4 +2,5 @@
 <resources>
 	<string name="app_name">Xamarin.Auth Sample (Android)</string>
 	<string name="Facebook">Login to Facebook</string>
+	<string name="FacebookNoCancel">Login to Facebook(no cancel)</string>
 </resources>

--- a/samples/Xamarin.Auth.Sample.iOS/AppDelegate.cs
+++ b/samples/Xamarin.Auth.Sample.iOS/AppDelegate.cs
@@ -12,13 +12,15 @@ namespace Xamarin.Auth.Sample.iOS
 	[Register ("AppDelegate")]
 	public partial class AppDelegate : UIApplicationDelegate
 	{
-		void LoginToFacebook ()
+		void LoginToFacebook (bool allowCancel)
 		{
 			var auth = new OAuth2Authenticator (
 				clientId: "App ID from https://developers.facebook.com/apps",
 				scope: "",
 				authorizeUrl: new Uri ("https://m.facebook.com/dialog/oauth/"),
 				redirectUrl: new Uri ("http://www.facebook.com/connect/login_success.html"));
+
+			auth.AllowCancel = allowCancel;
 
 			// If authorization succeeds or is canceled, .Completed will be fired.
 			auth.Completed += (s, e) =>
@@ -56,7 +58,8 @@ namespace Xamarin.Auth.Sample.iOS
 		public override bool FinishedLaunching (UIApplication app, NSDictionary options)
 		{
 			facebook = new Section ("Facebook");
-			facebook.Add (new StyledStringElement ("Log in", LoginToFacebook));
+			facebook.Add (new StyledStringElement ("Log in", delegate {LoginToFacebook(true); }));			
+			facebook.Add (new StyledStringElement ("Log in(no cancel)", delegate {LoginToFacebook(false); }));
 			facebook.Add (facebookStatus = new StringElement (String.Empty));
 
 			dialog = new DialogViewController (new RootElement ("Xamarin.Auth Sample") {

--- a/src/Xamarin.Auth.Android/WebAuthenticatorActivity.cs
+++ b/src/Xamarin.Auth.Android/WebAuthenticatorActivity.cs
@@ -114,7 +114,10 @@ namespace Xamarin.Auth
 
 		public override void OnBackPressed ()
 		{
-			state.Authenticator.OnCancelled ();
+			if (state.Authenticator.AllowCancel)
+			{
+				state.Authenticator.OnCancelled ();
+			}
 		}
 
 		public override Java.Lang.Object OnRetainNonConfigurationInstance ()

--- a/src/Xamarin.Auth.iOS/WebAuthenticatorController.cs
+++ b/src/Xamarin.Auth.iOS/WebAuthenticatorController.cs
@@ -51,11 +51,14 @@ namespace Xamarin.Auth
 			//
 			Title = authenticator.Title;
 
-			NavigationItem.LeftBarButtonItem = new UIBarButtonItem (
-				UIBarButtonSystemItem.Cancel,
-				delegate {
+			if (authenticator.AllowCancel)
+			{
+				NavigationItem.LeftBarButtonItem = new UIBarButtonItem (
+					UIBarButtonSystemItem.Cancel,
+					delegate {
 					Cancel ();
-				});
+				});				
+			}
 
 			activity = new UIActivityIndicatorView (UIActivityIndicatorViewStyle.White);
 			NavigationItem.RightBarButtonItem = new UIBarButtonItem (activity);

--- a/src/Xamarin.Auth/Authenticator.cs
+++ b/src/Xamarin.Auth/Authenticator.cs
@@ -45,6 +45,11 @@ namespace Xamarin.Auth
 		public string Title { get; set; }
 
 		/// <summary>
+		/// Indicates if the authenticator should be allowed to be cancelled.
+		/// </summary>
+		public bool AllowCancel { get; set; }
+
+		/// <summary>
 		/// Occurs when authentication has been successfully or unsuccessfully completed.
 		/// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
 		/// authentication was successful.
@@ -68,6 +73,7 @@ namespace Xamarin.Auth
 		{
 			Title = "Authenticate";
 			HasCompleted = false;
+			AllowCancel = true;
 		}
 
 #if PLATFORM_ANDROID

--- a/src/Xamarin.Auth/Xamarin.Auth.csproj
+++ b/src/Xamarin.Auth/Xamarin.Auth.csproj
@@ -19,7 +19,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <GenerateDocumentation>True</GenerateDocumentation>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -29,7 +28,6 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>False</ConsolePause>
-    <GenerateDocumentation>True</GenerateDocumentation>
     <TreatWarningsAsErrors>True</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>


### PR DESCRIPTION
Many classes of apps require authentication and therefore the ability
to cancel the process is unwanted, un-necessary and provides a poor
user experience. This commit adds the ability to block a user from
Cancelling the authentication process.

The two samples were extended to show how to disable canceling.
