### PR TITLE
Added flag for URL-escaping of scopes parameter

### DIFF
--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -43,7 +43,7 @@ namespace Xamarin.Auth
 		string requestState;
 		bool reportedForgery = false;
 
-		bool escapeScope = true;
+		bool encodeScope = true;
 
 		/// <summary>
 		/// Initializes a new <see cref="Xamarin.Auth.OAuth2Authenticator"/>
@@ -65,7 +65,7 @@ namespace Xamarin.Auth
 		/// Method used to fetch the username of an account
 		/// after it has been successfully authenticated.
 		/// </param>
-		public OAuth2Authenticator (string clientId, string scope, Uri authorizeUrl, Uri redirectUrl, bool escapeScope = true, GetUsernameAsyncFunc getUsernameAsync = null)
+		public OAuth2Authenticator (string clientId, string scope, Uri authorizeUrl, Uri redirectUrl, bool encodeScope = true, GetUsernameAsyncFunc getUsernameAsync = null)
 			: this (redirectUrl)
 		{
 			if (string.IsNullOrEmpty (clientId)) {
@@ -85,7 +85,7 @@ namespace Xamarin.Auth
 			}
 			this.redirectUrl = redirectUrl;
 
-			this.escapeScope = escapeScope;
+			this.encodeScope = encodeScope;
 
 			this.getUsernameAsync = getUsernameAsync;
 
@@ -118,7 +118,7 @@ namespace Xamarin.Auth
 		/// Method used to fetch the username of an account
 		/// after it has been successfully authenticated.
 		/// </param>
-		public OAuth2Authenticator (string clientId, string clientSecret, string scope, Uri authorizeUrl, Uri redirectUrl, Uri accessTokenUrl, bool escapeScope = true, GetUsernameAsyncFunc getUsernameAsync = null)
+		public OAuth2Authenticator (string clientId, string clientSecret, string scope, Uri authorizeUrl, Uri redirectUrl, Uri accessTokenUrl, bool encodeScope = true, GetUsernameAsyncFunc getUsernameAsync = null)
 			: this (redirectUrl, clientSecret, accessTokenUrl)
 		{
 			if (string.IsNullOrEmpty (clientId)) {
@@ -143,7 +143,7 @@ namespace Xamarin.Auth
 			}
 			this.redirectUrl = redirectUrl;
 
-			this.escapeScope = escapeScope;
+			this.encodeScope = encodeScope;
 
 			if (accessTokenUrl == null) {
 				throw new ArgumentNullException ("accessTokenUrl");
@@ -192,7 +192,7 @@ namespace Xamarin.Auth
 				Uri.EscapeDataString (clientId),
 				Uri.EscapeDataString (redirectUrl.AbsoluteUri),
 				IsImplicit ? "token" : "code",
-				(escapeScope) ? Uri.EscapeDataString (scope) : scope,
+				(encodeScope) ? Uri.EscapeDataString (scope) : scope,
 				Uri.EscapeDataString (requestState)));
 
 			var tcs = new TaskCompletionSource<Uri> ();


### PR DESCRIPTION
URL-encoding the scope parameter of an OAuth request to Instagram (and possibly other services as well) causes a failure. If the scope parameter is “scope=basic+likes+comments+relationships”, it is URL-escaped by the Xamarin.Auth OAuth2Authenticator to "scope=basic%2Blikes%2Bcomments%2Brelationships”. The auth endpoint at Instagram does not like this and replies with {"code": 400, "error_type": "OAuthException", "error_message": "Invalid scope field(s): basic+likes+”comments+relationships}. A misleading message for sure, because as the error message rendered to the browser, it's not obvious that the parameter has been encoded. I imagine that other services work similarly and also barf if the scope param is URL-encoded. So, I have added a flag to the OAuth2Authenticator constructors to enable/disable the URL-encoding of the scope parameter. I added a flag instead of just removing the URL-encoding altogether because I am unsure of the behavior of other OAuth services when it comes to this matter. By default, the original behavior will remain, but provides the option to NOT encode the scope parameter.
