### PR TITLE
MakeSecretOptional

### DIFF
--- a/src/Xamarin.Auth/OAuth2Authenticator.cs
+++ b/src/Xamarin.Auth/OAuth2Authenticator.cs
@@ -122,9 +122,6 @@ namespace Xamarin.Auth
 			}
 			this.clientId = clientId;
 
-			if (string.IsNullOrEmpty (clientSecret)) {
-				throw new ArgumentException ("clientSecret must be provided", "clientSecret");
-			}
 			this.clientSecret = clientSecret;
 
 			this.scope = scope ?? "";


### PR DESCRIPTION
Make client secret == null a valid scenario for authentication code
grant. The changes are submitted under the Apache license and were made to provide support for authenticating with Azure Active Directory.
