### PR TITLE
Fix : Android password field now hides the user input in FormAuthenticatorActivity

### DIFF
--- a/src/Xamarin.Auth.Android/FormAuthenticatorActivity.cs
+++ b/src/Xamarin.Auth.Android/FormAuthenticatorActivity.cs
@@ -142,19 +142,11 @@ namespace Xamarin.Auth
 				var editor = new EditText (this) {
 					Hint = f.Placeholder,
 				};
-                switch (f.FieldType)
-                {
-                    case FormAuthenticatorFieldType.Email:
-                        editor.InputType = InputTypes.TextVariationEmailAddress;
-                        break;
-                    case FormAuthenticatorFieldType.Password:
-                        editor.InputType = InputTypes.TextVariationPassword;
-                        editor.TransformationMethod = new Android.Text.Method.PasswordTransformationMethod();
-                        break;
-                    default:
-                        editor.InputType = InputTypes.TextVariationNormal;
-                        break;
-                }
+				if (f.FieldType == FormAuthenticatorFieldType.Password)
+				{
+					editor.InputType = InputTypes.TextVariationPassword;
+					editor.TransformationMethod = new Android.Text.Method.PasswordTransformationMethod();
+				}
 				row.AddView (editor);
 				fieldEditors [f] = editor;
 

--- a/src/Xamarin.Auth.Android/FormAuthenticatorActivity.cs
+++ b/src/Xamarin.Auth.Android/FormAuthenticatorActivity.cs
@@ -18,6 +18,7 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Android.Content;
+using Android.Text;
 using Android.Views;
 using Android.App;
 using Android.OS;
@@ -141,6 +142,19 @@ namespace Xamarin.Auth
 				var editor = new EditText (this) {
 					Hint = f.Placeholder,
 				};
+                switch (f.FieldType)
+                {
+                    case FormAuthenticatorFieldType.Email:
+                        editor.InputType = InputTypes.TextVariationEmailAddress;
+                        break;
+                    case FormAuthenticatorFieldType.Password:
+                        editor.InputType = InputTypes.TextVariationPassword;
+                        editor.TransformationMethod = new Android.Text.Method.PasswordTransformationMethod();
+                        break;
+                    default:
+                        editor.InputType = InputTypes.TextVariationNormal;
+                        break;
+                }
 				row.AddView (editor);
 				fieldEditors [f] = editor;
 


### PR DESCRIPTION
In Android, when using fields configured with type `FormAuthenticatorFieldType.Password` in a `FormAuthenticatorActivity`, they display their values just like regular text fields. This pull request fixes the issue and gets password fields to hide their input values as expected.

Submitted under an [Apache 2.0 license](http://www.apache.org/licenses/LICENSE-2.0.html).
