### PR TITLE
Marshalled NavigationService.GoBack to UI Thread

### DIFF
--- a/src/Xamarin.Auth.WindowsPhone8/WebAuthenticatorPage.xaml.cs
+++ b/src/Xamarin.Auth.WindowsPhone8/WebAuthenticatorPage.xaml.cs
@@ -40,7 +40,13 @@ namespace Xamarin.Auth.WindowsPhone
 			string key = NavigationContext.QueryString["key"];
 
 			this.auth = (WebAuthenticator)PhoneApplicationService.Current.State[key];
-			this.auth.Completed += (sender, args) => NavigationService.GoBack();
+            this.auth.Completed += (sender, args) =>
+            {
+                Dispatcher.BeginInvoke(() =>
+                {
+                    NavigationService.GoBack();
+                });
+            };
 			this.auth.Error += OnAuthError;
 
 			PhoneApplicationService.Current.State.Remove (key);


### PR DESCRIPTION
Added code to marshal the NavigationService.GoBack call to the UI thread
to avoid an invalid cross thread access exception when using OAuth1 on
Windows Phone