### PR TITLE
Prevent duplicate handling of redirect page loaded

### DIFF
--- a/src/Xamarin.Auth/WebRedirectAuthenticator.cs
+++ b/src/Xamarin.Auth/WebRedirectAuthenticator.cs
@@ -87,6 +87,13 @@ namespace Xamarin.Auth
 			var fragment = WebEx.FormDecode (url.Fragment);
 
 			OnPageEncountered (url, query, fragment);
+
+			//
+			// Watch for the redirect
+			//
+			if (UrlMatchesRedirect (url)) {
+				OnRedirectPageLoaded (url, query, fragment);
+			}
 		}
 
 		/// <summary>
@@ -138,13 +145,6 @@ namespace Xamarin.Auth
 				}
 				OnError (description);
 				return;
-			}
-
-			//
-			// Watch for the redirect
-			//
-			if (UrlMatchesRedirect (url)) {
-				OnRedirectPageLoaded (url, query, fragment);
 			}
 		}
 


### PR DESCRIPTION
When the redirect page is requested, OnPageEncountered is called for both page loading and page loaded events. One side effect is duplicate POST requests to exchange authentication codes for tokens. With certain OAuth providers, resubmitting the OAuth code for a second token results in an exception. This change prevents the duplicate handling by only calling RedirectPageLoaded inside the OnPageLoaded event handler.
