### PR TITLE
Add ability to hide error dialog boxes

### DIFF
--- a/source/Xamarin.Auth.LinkSource/Authenticator.cs
+++ b/source/Xamarin.Auth.LinkSource/Authenticator.cs
@@ -63,12 +63,18 @@ namespace Xamarin.Auth
 		/// <value><c>true</c> by default.</value>
 		public bool AllowCancel { get; set; }
 
-		/// <summary>
-		/// Occurs when authentication has been successfully or unsuccessfully completed.
-		/// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
-		/// authentication was successful.
+        /// <summary>
+		/// Gets or sets whether Xamarin.Auth should display login errors.
 		/// </summary>
-		public event EventHandler<AuthenticatorCompletedEventArgs> Completed;
+		/// <value><c>true</c> by default.</value>
+		public bool ShowErrors { get; set; }
+
+        /// <summary>
+        /// Occurs when authentication has been successfully or unsuccessfully completed.
+        /// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
+        /// authentication was successful.
+        /// </summary>
+        public event EventHandler<AuthenticatorCompletedEventArgs> Completed;
 
 		/// <summary>
 		/// Occurs when there an error is encountered when authenticating.
@@ -104,6 +110,7 @@ namespace Xamarin.Auth
 			Title = "Authenticate";
 			HasCompleted = false;
 			AllowCancel = true;
+             ShowErrors = true;
 			#region
 			//---------------------------------------------------------------------------------------
 			/// Pull Request - manually added/fixed

--- a/source/Xamarin.Auth.LinkSource/Authenticator.cs
+++ b/source/Xamarin.Auth.LinkSource/Authenticator.cs
@@ -63,18 +63,18 @@ namespace Xamarin.Auth
 		/// <value><c>true</c> by default.</value>
 		public bool AllowCancel { get; set; }
 
-        /// <summary>
+                /// <summary>
 		/// Gets or sets whether Xamarin.Auth should display login errors.
 		/// </summary>
 		/// <value><c>true</c> by default.</value>
 		public bool ShowErrors { get; set; }
 
-        /// <summary>
-        /// Occurs when authentication has been successfully or unsuccessfully completed.
-        /// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
-        /// authentication was successful.
-        /// </summary>
-        public event EventHandler<AuthenticatorCompletedEventArgs> Completed;
+                /// <summary>
+                /// Occurs when authentication has been successfully or unsuccessfully completed.
+                /// Consult the <see cref="AuthenticatorCompletedEventArgs.IsAuthenticated"/> event argument to determine if
+                /// authentication was successful.
+                /// </summary>
+                public event EventHandler<AuthenticatorCompletedEventArgs> Completed;
 
 		/// <summary>
 		/// Occurs when there an error is encountered when authenticating.
@@ -110,7 +110,7 @@ namespace Xamarin.Auth
 			Title = "Authenticate";
 			HasCompleted = false;
 			AllowCancel = true;
-             ShowErrors = true;
+                        ShowErrors = true;
 			#region
 			//---------------------------------------------------------------------------------------
 			/// Pull Request - manually added/fixed

--- a/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/FormAuthenticatorActivity.cs
+++ b/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/FormAuthenticatorActivity.cs
@@ -78,7 +78,11 @@ namespace Xamarin.Auth
 				Finish ();
 			};
 			state.Authenticator.Error += (s, e) => {
-				if (e.Exception != null) {
+
+                if (!state.Authenticator.ShowErrors)
+                    return;
+
+                if (e.Exception != null) {
 					this.ShowError ("Authentication Error", e.Exception);
 				}
 				else {

--- a/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/FormAuthenticatorActivity.cs
+++ b/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/FormAuthenticatorActivity.cs
@@ -79,10 +79,10 @@ namespace Xamarin.Auth
 			};
 			state.Authenticator.Error += (s, e) => {
 
-                if (!state.Authenticator.ShowErrors)
-                    return;
+                                if (!state.Authenticator.ShowErrors)
+                                         return;
 
-                if (e.Exception != null) {
+                                if (e.Exception != null) {
 					this.ShowError ("Authentication Error", e.Exception);
 				}
 				else {

--- a/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.cs
+++ b/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.cs
@@ -96,10 +96,11 @@ namespace Xamarin.Auth
 				Finish ();
 			};
 			state.Authenticator.Error += (s, e) => {
-                if (!state.Authenticator.ShowErrors)
-                    return;
 
-                if (e.Exception != null) {
+                                if (!state.Authenticator.ShowErrors)
+                                        return;
+
+                                if (e.Exception != null) {
 					this.ShowError ("Authentication Error", e.Exception);
 				}
 				else {
@@ -154,10 +155,10 @@ namespace Xamarin.Auth
 			state.Authenticator.GetInitialUrlAsync ().ContinueWith (t => {
 				if (t.IsFaulted) {
 
-                    if (!state.Authenticator.ShowErrors)
-                        return;
+                                        if (!state.Authenticator.ShowErrors)
+                                                return;
 
-                    this.ShowError ("Authentication Error", t.Exception);
+                                        this.ShowError ("Authentication Error", t.Exception);
 				}
 				else {
 					webView.LoadUrl (t.Result.AbsoluteUri);

--- a/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.cs
+++ b/source/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.cs
@@ -96,7 +96,10 @@ namespace Xamarin.Auth
 				Finish ();
 			};
 			state.Authenticator.Error += (s, e) => {
-				if (e.Exception != null) {
+                if (!state.Authenticator.ShowErrors)
+                    return;
+
+                if (e.Exception != null) {
 					this.ShowError ("Authentication Error", e.Exception);
 				}
 				else {
@@ -150,7 +153,11 @@ namespace Xamarin.Auth
 		{
 			state.Authenticator.GetInitialUrlAsync ().ContinueWith (t => {
 				if (t.IsFaulted) {
-					this.ShowError ("Authentication Error", t.Exception);
+
+                    if (!state.Authenticator.ShowErrors)
+                        return;
+
+                    this.ShowError ("Authentication Error", t.Exception);
 				}
 				else {
 					webView.LoadUrl (t.Result.AbsoluteUri);

--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/FormAuthenticatorController.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/FormAuthenticatorController.cs
@@ -74,7 +74,11 @@ namespace Xamarin.Auth
 				StopProgress ();
 
 				if (task.IsFaulted) {
-					this.ShowError ("Error Signing In", task.Exception);
+
+                    if (!state.Authenticator.ShowErrors)
+                        return;
+
+                    this.ShowError ("Error Signing In", task.Exception);
 				}
 				else {
 					authenticator.OnSucceeded (task.Result);

--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/FormAuthenticatorController.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/FormAuthenticatorController.cs
@@ -75,10 +75,10 @@ namespace Xamarin.Auth
 
 				if (task.IsFaulted) {
 
-                    if (!state.Authenticator.ShowErrors)
-                        return;
+                                        if (!authenticator.ShowErrors)
+                                                return;
 
-                    this.ShowError ("Error Signing In", task.Exception);
+                                        this.ShowError ("Error Signing In", task.Exception);
 				}
 				else {
 					authenticator.OnSucceeded (task.Result);

--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
@@ -175,10 +175,10 @@ namespace Xamarin.Auth
 				(Action)BeginLoadingInitialUrl :
 				(Action)Cancel;
 
-            if (!authenticator.ShowErrors)
-                return;
+                        if (!authenticator.ShowErrors)
+                                return;
 
-            if (e.Exception != null) {
+                        if (e.Exception != null) {
 				this.ShowError ("Authentication Error", e.Exception, after);
 			}
 			else {

--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
@@ -175,7 +175,10 @@ namespace Xamarin.Auth
 				(Action)BeginLoadingInitialUrl :
 				(Action)Cancel;
 
-			if (e.Exception != null) {
+            if (!authenticator.ShowErrors)
+                return;
+
+            if (e.Exception != null) {
 				this.ShowError ("Authentication Error", e.Exception, after);
 			}
 			else {


### PR DESCRIPTION
Users should be in control if they want to handle pop up dialog boxes.
This adds a "ShowErrors" property, which defaults to true and will hide
all pop ups if set to false.