### PR TITLE
Preventing "android.view.WindowManager$BadTokenException: Unable to a…

### DIFF
--- a/src/Xamarin.Auth.Android/ActivityEx.cs
+++ b/src/Xamarin.Auth.Android/ActivityEx.cs
@@ -16,6 +16,9 @@ namespace Xamarin.Utilities.Android
 
 		public static void ShowError (this Activity activity, string title, string message)
 		{
+			if (activity.IsFinishing)
+				return;
+
 			var b = new AlertDialog.Builder (activity);
 			b.SetMessage (message);
 			b.SetTitle (title);


### PR DESCRIPTION
…dd window" which can happen if trying to show the alert dialog from an async method when the activity is finishing.

This is a often triggered exception coming from Xamarin.Auth. This can happen if OnError method is run and the passed in activity is in "IsFinishing" state.

I reckon to prevent the error with bad token it's better to check if the activity is finishing and then avoid displaying the error.