### PR TITLE
Fixed always showing error message alert regardless of setting.

### DIFF
--- a/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
+++ b/source/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.cs
@@ -270,7 +270,12 @@ namespace Xamarin.Auth
                 (Action)BeginLoadingInitialUrl :
                 (Action)Cancel;
 
-            if ( authenticator.ShowErrors == true && e.Exception != null)
+            if ( !authenticator.ShowErrors ) {
+                after();
+                return;
+            }
+
+            if ( e.Exception != null)
             {
                 this.ShowError("Authentication Error e.Exception = ", e.Exception, after);
             }


### PR DESCRIPTION
This is the way it is currently handled on [master](https://github.com/xamarin/Xamarin.Auth/blob/master/src/Xamarin.Auth.iOS/WebAuthenticatorController.cs#L173).