### PR TITLE
Added two properties to allow a developer to specify when to call OnP…

### DIFF
--- a/source/Xamarin.Auth.LinkSource/WebRedirectAuthenticator.cs
+++ b/source/Xamarin.Auth.LinkSource/WebRedirectAuthenticator.cs
@@ -78,7 +78,11 @@ namespace Xamarin.Auth
 			this.Query = query;
 			this.Fragment = fragment;
 
-			OnPageEncountered(url, query, fragment);
+
+            if (ShouldEncounterOnPageLoaded)
+            {
+                OnPageEncountered(url, query, fragment);
+            }
 
             return;
         }
@@ -116,8 +120,10 @@ namespace Xamarin.Auth
 
             // mc++
             // TODO: schemas
-            OnPageEncountered(url, query, fragment);
-
+            if (ShouldEncounterOnPageLoading)
+            {
+                OnPageEncountered(url, query, fragment);
+            }
             return;
         }
 
@@ -224,6 +230,28 @@ namespace Xamarin.Auth
             get;
             set;
         } = false;
+
+
+		/// <summary>
+		/// Sets a value indicating whether OnPageEncountered gets fired during OnPageLoading.
+		/// </summary>       
+		/// <value><c>true</c> if OnPageEncountered should be fired in OnPageLoading; otherwise, <c>false</c>.</value>
+		public bool ShouldEncounterOnPageLoading
+        {
+            get;
+            set;
+        } = true;
+
+
+		/// <summary>
+		/// Sets a value indicating whether OnPageEncountered gets fired during OnPageLoaded.
+		/// </summary>       
+		/// <value><c>true</c> if OnPageEncountered should be fired in OnPageLoaded; otherwise, <c>false</c>.</value>
+		public bool ShouldEncounterOnPageLoaded
+        {
+            get;
+            set;
+        } = true;
 
     }
 }


### PR DESCRIPTION
…ageEncountered

# Xamarin.Auth Pull Request

Fixes  #127 .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Added two new properties, ShouldEncounterOnPageLoaded and ShouldEncounterOnPageLoading. These are true by default so any existing apps will behave as they already did. Setting one to false will prevent OnPageEncountered from potentially being called twice. It gives the developer added flexibility of when they want to fire OnPageEncountered, when the page starts loading, or when the page has fully loaded.

Having ShouldEncounterOnPageLoaded and ShouldEncounterOnPageLoading both set to true was causing us issues with LinkedIn as trying to authenticate a second time (from OnPageLoaded) would cause an invalid grant error. I believe it also invalidates the original access token.