### PR TITLE
Make iOS Native-UI http redirect_uri warning conditional

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinIOS/WebAuthenticator.XamarinIOS.cs
+++ b/source/Core/Xamarin.Auth.XamarinIOS/WebAuthenticator.XamarinIOS.cs
@@ -58,18 +58,21 @@ namespace Xamarin.Auth._MobileServices
             {
                 Uri uri = GetInitialUrlAsync().Result;
                 IDictionary<string, string> query_parts = WebEx.FormDecode(uri.Query);
-                Uri redirect_uri = new Uri(query_parts["redirect_uri"]);
-                string scheme = redirect_uri.Scheme;
-                if (scheme.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+                if (query_parts.ContainsKey("redirect_uri"))
                 {
-                    StringBuilder sb = new StringBuilder();
-                    sb.AppendLine("WARNING");
-                    sb.AppendLine($"Scheme = {scheme}");
-                    sb.AppendLine($"Native UI used with http[s] schema!");
-                    sb.AppendLine($"Redirect URL will be loaded in Native UI!");
-                    sb.AppendLine($"OAuth Data parsing might fail!");
+                    Uri redirect_uri = new Uri(query_parts["redirect_uri"]);
+                    string scheme = redirect_uri.Scheme;
+                    if (scheme.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+                    {
+                        StringBuilder sb = new StringBuilder();
+                        sb.AppendLine("WARNING");
+                        sb.AppendLine($"Scheme = {scheme}");
+                        sb.AppendLine($"Native UI used with http[s] schema!");
+                        sb.AppendLine($"Redirect URL will be loaded in Native UI!");
+                        sb.AppendLine($"OAuth Data parsing might fail!");
 
-                    ShowErrorForNativeUI(sb.ToString());
+                        ShowErrorForNativeUI(sb.ToString());
+                    }
                 }
                 ui = GetPlatformUINative();
             }


### PR DESCRIPTION
Warning for Redirect URL containing http only useful where a redirect_uri exists (such as OAuth2). OAuth1 implementations currently crash when loading the native UI as they do not have a redirect_uri key in the query_parts dictionary, but otherwise work fine if this warning flow is skipped.