### PR TITLE
Fix ambiguous project name on NuGet restore

### DIFF
--- a/source/Core/Xamarin.Auth.NetStandard10.ReferenceAssembly/Xamarin.Auth.NetStandard10.ReferenceAssembly.csproj
+++ b/source/Core/Xamarin.Auth.NetStandard10.ReferenceAssembly/Xamarin.Auth.NetStandard10.ReferenceAssembly.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFramework>netstandard1.0</TargetFramework>
     <RootNamespace>Xamarin.Auth</RootNamespace>
-    <AssemblyName>Xamarin.Auth.XamarinForms</AssemblyName>
+    <AssemblyName>Xamarin.Auth</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed the ambigous project name 'Xamarin.Auth.XamarinForms' error
message when restoring NuGet packages. The wrong assembly name
was being used in the Xamarin.Auth.NetStandard10.ReferenceAssembly
project.
