### PR TITLE
Check fragment before calling OnSucceeded in OnRedirectPageLoaded

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
@@ -219,7 +219,10 @@ namespace Xamarin.Auth._MobileServices
             #endif
 
             // TODO:  mc++ schemas
-            OnSucceeded("N/A", fragment);
+            if (fragment.Any())
+            {
+                OnSucceeded("N/A", fragment);
+            }
 
             return;
         }


### PR DESCRIPTION
Some providers redirect tokens (such as oauth_verifier) to the callbackUrl before the OAuth process is complete, and require a further step to finish authentication. Checking whether the fragment is empty at this point allows the process to complete and correctly authenticate the user.