### PR TITLE
Fix OAuth2Authenticator checking for CSRF foregeries

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -895,24 +895,11 @@ namespace Xamarin.Auth._MobileServices
             ///		OAuth2Authenticator changes to work with joind.in OAuth #91
             ///		https://github.com/xamarin/Xamarin.Auth/pull/91
             ///		
-            //else if (data.ContainsKey("access_token"))
-            else if (data.ContainsKey(AccessTokenName))
             //---------------------------------------------------------------------------------------
             #endregion
+            else if (!data.ContainsKey(AccessTokenName))
             {
-            }
-            else
-            {
-                #region
-                //---------------------------------------------------------------------------------------
-                /// Pull Request - manually added/fixed
-                ///		OAuth2Authenticator changes to work with joind.in OAuth #91
-                ///		https://github.com/xamarin/Xamarin.Auth/pull/91
-                ///		
-                //throw new AuthException ("Expected access_token in access token response, but did not receive one.");
                 throw new AuthException("Expected " + AccessTokenName + " in access token response, but did not receive one.");
-                //---------------------------------------------------------------------------------------
-                #endregion
             }
 
             return data;

--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -124,6 +124,18 @@ namespace Xamarin.Auth._MobileServices
         }
 
         /// <summary>
+        /// Gets the redirect URL.
+        /// </summary>
+        /// <value>The redirect URL.</value>
+        public Uri RedirectUrl 
+        { 
+            get
+            {
+                return this.redirectUrl;
+            }
+        }
+
+        /// <summary>
         /// Gets the access token URL.
         /// </summary>
         /// <value>The URL used to request access tokens after an authorization code was received.</value>

--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -634,8 +634,6 @@ namespace Xamarin.Auth._MobileServices
         /// <summary>
         /// OAuth flow response type verification
         /// 1. 
-        /// 
-        /// 
         ///     https://alexbilbie.com/guide-to-oauth-2-grants/
         /// 
         /// </summary>
@@ -845,8 +843,6 @@ namespace Xamarin.Auth._MobileServices
                     OnError("Expected " + AccessTokenName + " in response, but did not receive one.");
                     //---------------------------------------------------------------------------------------
                     #endregion
-
-                    return;
                 }
             }
         }

--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -735,8 +735,14 @@ namespace Xamarin.Auth._MobileServices
         protected override void OnPageEncountered(Uri url, IDictionary<string, string> query, IDictionary<string, string> fragment)
         {
             var all = new Dictionary<string, string>(query);
+
+            foreach (var kv in fragment)
+            {
+                all[kv.Key] = kv.Value;
+            }
+
             //
-            // Check for forgeries
+            // Check for CSRF forgeries
             //
             if (all.ContainsKey("state"))
             {


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes 
- #285 OAuth2Authenticator does not check CSRF foregeries in Implicit Grant

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Also adding a public RedirectUrl getter in OAuth2Authenticator, the other fields have one already.
- Also cleaning up minor things
