### PR TITLE
UWP fix for allowing subclasses of OAuth2Authenticator

### DIFF
--- a/source/Core/Xamarin.Auth.UniversalWindowsPlatform/WebAuthenticatorPage.Events.xaml.cs
+++ b/source/Core/Xamarin.Auth.UniversalWindowsPlatform/WebAuthenticatorPage.Events.xaml.cs
@@ -31,19 +31,11 @@ namespace Xamarin.Auth._MobileServices
         {
             if (null == authenticator)
             {
-                Type type_authenticator = e.Parameter.GetType();
-                if (type_authenticator == typeof(OAuth1Authenticator))
+                authenticator = e.Parameter as WebRedirectAuthenticator;
+                if (authenticator == null)
                 {
-                    authenticator = e.Parameter as OAuth1Authenticator;
-                }
-                else if (type_authenticator == typeof(OAuth2Authenticator))
-                {
-                    authenticator = e.Parameter as OAuth2Authenticator;
-                }
-                else
-                {
-                    System.Diagnostics.Debug.WriteLine($"Invalid Authenticator {type_authenticator}");
-                    throw new Xamarin.Auth.AuthException($"Invalid Authenticator {type_authenticator}");
+                    System.Diagnostics.Debug.WriteLine($"Invalid Authenticator {e.Parameter?.GetType().ToString() ?? "null"}");
+                    throw new Xamarin.Auth.AuthException($"Invalid Authenticator {e.Parameter?.GetType().ToString() ?? "null"}");
                 }
             }
 


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes #280  .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- updated WebRedirectAuthenticator check in UWP WebAuthenticatorPage.Events.xaml.cs to allow all subclasses of correct type

