### PR TITLE
Add datacontainer based AccountStore and make it the default

### DIFF
--- a/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/AccountStore.WindowsUWP.cs
+++ b/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/AccountStore.WindowsUWP.cs
@@ -38,6 +38,14 @@ namespace Xamarin.Auth._MobileServices
         /// </summary>
         public static AccountStore Create()
         {
+            return new WindowsUWP.DataContainerAccountStore();
+        }
+
+        /// <summary>
+        /// Create an account store based on individual files instead of the UWP datacontainer
+        /// </summary>
+        public static AccountStore CreateFileBased()
+        {
             return new WindowsUWP.UWPAccountStore();
         }
 

--- a/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/DataContainerAccountStore.async.cs
+++ b/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/DataContainerAccountStore.async.cs
@@ -1,0 +1,86 @@
+﻿//
+//  Copyright 2013, Xamarin Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Runtime.InteropServices.WindowsRuntime;
+using System.Text;
+using System.Threading.Tasks;
+using Windows.Storage;
+
+namespace Xamarin.Auth.WindowsUWP
+{
+    internal partial class DataContainerAccountStore
+    {
+        public override Task DeleteAsync(Account account, string serviceId)
+        {
+            if (account == null)
+                throw new ArgumentNullException(nameof(account));
+            if (account.Username?.Length == 0)
+                throw new ArgumentOutOfRangeException(nameof(account), "Username cannot be empty");
+
+            ApplicationDataContainer container = GetDataContainer(serviceId);
+            if (container.Values.ContainsKey(account.Username))
+                container.Values.Remove(account.Username);
+
+            return Task.CompletedTask;
+        }
+
+        public override async Task<List<Account>> FindAccountsForServiceAsync(string serviceId)
+        {
+            ApplicationDataContainer container = GetDataContainer(serviceId);
+            List<Account> accounts = new List<Account>();
+            foreach (byte[] data in container.Values.Values.ToArray())
+            {
+                byte[] unprot = (await DataProtectionExtensions.UnprotectAsync(data.AsBuffer()).ConfigureAwait(false)).ToArray();
+                accounts.Add(Account.Deserialize(Encoding.UTF8.GetString(unprot, 0, unprot.Length)));
+            }
+
+            return accounts;
+        }
+
+        public override Task SaveAsync(Account account, string serviceId)
+        {
+            return SaveAsync(account, serviceId, null);
+        }
+
+        public async Task SaveAsync(Account account, string serviceId, Uri uri)
+        {
+            if (account == null)
+                throw new ArgumentNullException(nameof(account));
+            if (account.Username?.Length == 0)
+                throw new ArgumentOutOfRangeException(nameof(account), "Username cannot be empty");
+
+            ApplicationDataContainer container = GetDataContainer(serviceId);
+
+            byte[] data = Encoding.UTF8.GetBytes(uri == null ? account.Serialize() : account.Serialize(uri));
+            byte[] prot = (await DataProtectionExtensions.ProtectAsync(data.AsBuffer())).ToArray();
+
+            container.Values[account.Username] = prot;
+        }
+
+        private static ApplicationDataContainer GetDataContainer(string serviceId)
+        {
+            ApplicationDataContainer localSettings = ApplicationData.Current.LocalSettings;
+            string name = $"xamarin.auth.accountstore.{serviceId}";
+
+            if (!localSettings.Containers.ContainsKey(name))
+                localSettings.CreateContainer(name, ApplicationDataCreateDisposition.Always);
+            return localSettings.Containers[name];
+        }
+    }
+}

--- a/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/DataContainerAccountStore.cs
+++ b/source/Core/Xamarin.Auth.UniversalWindowsPlatform/AccountStore/DataContainerAccountStore.cs
@@ -1,0 +1,43 @@
+﻿//
+//  Copyright 2013, Xamarin Inc.
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//
+//        http://www.apache.org/licenses/LICENSE-2.0
+//
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Xamarin.Auth.WindowsUWP
+{
+    internal partial class DataContainerAccountStore : AccountStore
+    {
+        public override void Delete(Account account, string serviceId)
+        {
+            Task t = DeleteAsync(account, serviceId);
+
+            return;
+        }
+
+        public override IEnumerable<Account> FindAccountsForService(string serviceId)
+        {
+            return FindAccountsForServiceAsync(serviceId).Result;
+        }
+
+        public override void Save(Account account, string serviceId)
+        {
+            Task t = SaveAsync(account, serviceId);
+
+            return;
+        }
+    }
+}

--- a/source/Core/Xamarin.Auth.UniversalWindowsPlatform/Xamarin.Auth.UniversalWindowsPlatform.csproj
+++ b/source/Core/Xamarin.Auth.UniversalWindowsPlatform/Xamarin.Auth.UniversalWindowsPlatform.csproj
@@ -125,6 +125,8 @@
       <Link>AccountStore\AccountStore.cs</Link>
     </Compile>
     <Compile Include="AccountStore\AccountStore.WindowsUWP.cs" />
+    <Compile Include="AccountStore\DataContainerAccountStore.async.cs" />
+    <Compile Include="AccountStore\DataContainerAccountStore.cs" />
     <Compile Include="AccountStore\UWPAccountStore.Async.cs" />
     <Compile Include="AccountStore\UWPAccountStore.cs" />
     <Compile Include="..\Xamarin.Auth.Common.LinkSource\AssemblyInfo.cs">


### PR DESCRIPTION
Add datacontainer based AccountStore and make it the default. Added o…ption to user AccountStore.CreateFileBased() if an app has existing accounts stored in files

To be completely backwards compatible, those should be swithed around ofcourse

# Xamarin.Auth Pull Request

Fixes #327 .

### Checklist

- [X] I have included examples or tests => existing samples work transparently with this store
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Use a datacontainer as default store on UWP
