### PR TITLE
Fix issue #324

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/CustomTabActivityHelper.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/CustomTabActivityHelper.cs
@@ -106,7 +106,7 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
 
 				CustomTabsHelper.AddKeepAliveExtra(activity, custom_tabs_intent.Intent);
 
-                custom_tabs_intent.LaunchUrl(activity, uri);
+                //custom_tabs_intent.LaunchUrl(activity, uri);
 				custom_tabs_activity_manager.CustomTabsServiceConnected +=
                                 // custom_tabs_activit_manager_CustomTabsServiceConnected
                                 delegate


### PR DESCRIPTION
https://github.com/xamarin/Xamarin.Auth/issues/324

# Xamarin.Auth Pull Request

Fixes #324 

### Checklist

- [X] I have included examples or tests
You can try my demo project i tested
https://github.com/lewixlabs/OAuth2Forms/tree/master/OAuth2Forms

### Changes proposed in this pull request:

- Removed double call of
`custom_tabs_intent.LaunchUrl(activity, uri);`
which makes Chrome CustomTab appearing twice during oauth2 session, after tapping the first "X" button