### PR TITLE
Check ShowErrors before showing UI error message

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.XamarinAndroid.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.XamarinAndroid.cs
@@ -70,28 +70,31 @@ namespace Xamarin.Auth._MobileServices
 
         protected void ShowErrorForNativeUIAlert(string v)
         {
-            global::Android.Content.Context c = global::Android.App.Application.Context;
-            new Plugin.Threading.UIThreadRunInvoker(c).BeginInvokeOnUIThread
-                                (
-                                    () =>
-                                    {
-                                        var b = new global::Android.App.AlertDialog.Builder(c);
-                                        b.SetMessage(v);
-                                        b.SetTitle("Warning");
-                                        b.SetNeutralButton
-                                         (
-                                             "OK", 
-                                             (s, e) =>
-                                            {
-                                                ((global::Android.App.AlertDialog)s).Cancel();
-                                            }
-                                        );
-                                        var alert = b.Create();
-                                        alert.Show();
+            if (this.ShowErrors)
+            {
+                global::Android.Content.Context c = global::Android.App.Application.Context;
+                new Plugin.Threading.UIThreadRunInvoker(c).BeginInvokeOnUIThread
+                                    (
+                                        () =>
+                                        {
+                                            var b = new global::Android.App.AlertDialog.Builder(c);
+                                            b.SetMessage(v);
+                                            b.SetTitle("Warning");
+                                            b.SetNeutralButton
+                                             (
+                                                 "OK",
+                                                 (s, e) =>
+                                                {
+                                                    ((global::Android.App.AlertDialog)s).Cancel();
+                                                }
+                                            );
+                                            var alert = b.Create();
+                                            alert.Show();
 
-                                    }
-                                );
-            return;
+                                        }
+                                    );
+                return;
+            }
         }
     }
 }

--- a/source/Core/Xamarin.Auth.XamarinIOS/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.XamarinIOS.cs
+++ b/source/Core/Xamarin.Auth.XamarinIOS/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.XamarinIOS.cs
@@ -71,23 +71,26 @@ namespace Xamarin.Auth
 
         protected void ShowErrorForNativeUIAlert(string v)
         {
-            new Plugin.Threading.UIThreadRunInvoker().BeginInvokeOnUIThread
-                                (
-                                    () =>
-                                    {
-                                        UIKit.UIAlertView alert = null;
-                                        alert = new UIKit.UIAlertView
-                                                        (
-                                                            "WARNING", 
-                                                            v, 
-                                                            null, 
-                                                            "Ok", 
-                                                            null
-                                                        );
-                        				alert.Show();                                        
-                                    }
-                                );
-            return;
+            if (this.ShowErrors)
+            {
+                new Plugin.Threading.UIThreadRunInvoker().BeginInvokeOnUIThread
+                                    (
+                                        () =>
+                                        {
+                                            UIKit.UIAlertView alert = null;
+                                            alert = new UIKit.UIAlertView
+                                                            (
+                                                                "WARNING",
+                                                                v,
+                                                                null,
+                                                                "Ok",
+                                                                null
+                                                            );
+                                            alert.Show();
+                                        }
+                                    );
+                return;
+            }
         }
     }
 }


### PR DESCRIPTION
Check Authenticator's ShowErrors before showing a UIAlertView to the user. 
At the moment ShowErrors only suppresses some errors (specifically from the OAuth flow itself), but ShowErrors being false should suppress all UI errors (such as the https scheme warning on native UI).