### PR TITLE
Fix OAuth authenticator for Instagram authentication #350 and #360.

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
@@ -163,7 +163,7 @@ namespace Xamarin.Auth._MobileServices
             //
             // Check for errors
             //
-            if (all.ContainsKey("error"))
+            if (all.ContainsKey("error") && UrlMatchesRedirect(url))
             {
                 string description = all["error"];
                 if (all.ContainsKey("error_description"))


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes # 
On ios device when loading the authentication page from Instagram, an error with "unknown_user" popup from OnPageLoaded event, because it was catching the intermediate callback from Facebook which also has 'error' url segment.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-
