### PR TITLE
Fix authentication callback blink issue on Android

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/WebAuthenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/WebAuthenticator.cs
@@ -90,6 +90,11 @@ namespace Xamarin.Auth._MobileServices
             return;
         }
 
+        public virtual bool CanNavigateTo(Uri uri)
+        {
+            return true;
+        }
+
         /// <summary>
         /// Event handler called when a new page has been loaded in the web browser.
         /// Implementations should call <see cref="Authenticator.OnSucceeded(Xamarin.Auth.Account)"/> if this page

--- a/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
@@ -133,6 +133,11 @@ namespace Xamarin.Auth._MobileServices
             return;
         }
 
+        public override bool CanNavigateTo(Uri uri)
+        {
+            return !UrlMatchesRedirect(uri);
+        }
+
         /// <summary>
         /// Raised when a new page has been encountered.
         /// </summary>

--- a/source/Core/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.WebClient.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/PlatformSpecific/WebAuthenticatorActivity.WebClient.cs
@@ -69,8 +69,12 @@ namespace Xamarin.Auth._MobileServices
                 #endif
 
                 bool should_override = false;
-
-                if (url != null && scheme == "http" /*url.StartsWith("http://")*/)
+                
+                if(Uri.TryCreate(url, UriKind.RelativeOrAbsolute, out Uri uri) && !activity.state.Authenticator.CanNavigateTo(uri))
+                {
+                    should_override = true;
+                }
+                else if (url != null && scheme == "http" /*url.StartsWith("http://")*/)
                 {
                     should_override = false;
                 }


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes # 
When authentication was completed on Android device, and redirecting to the redirecting URL, there was a blink happening (because the redirect page was showing for a quick moment).

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- Added virtual method `CanNavigateTo` in `Xamarin.Auth.WebAuthenticator` to prevent navigating to a redirect url.
- Added override method `CanNavigateTo` in `Xamarin.Auth.WebRedirectAuthenticator` to override default behavior of `Xamarin.Auth.WebAuthenticator`
