### PR TITLE
fixed spelling mistake in android browser redirect label

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/WebAuthenticatorNativeBrowserActivity.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/WebAuthenticatorNativeBrowserActivity.cs
@@ -33,7 +33,7 @@ namespace Xamarin.Auth._MobileServices
 {
     [Activity
         (
-            Label = "Web Authenticator Native Broswer",
+            Label = "Web Authenticator Native Browser",
             // NoHistory = true,
             LaunchMode = global::Android.Content.PM.LaunchMode.SingleTop
         )


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes #364  .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-Fixed spelling mistake in android browser redirect label
