### PR TITLE
Update Xamarin.Auth.XamarinForms.nuspec

### DIFF
--- a/nuget/Xamarin.Auth.XamarinForms.nuspec
+++ b/nuget/Xamarin.Auth.XamarinForms.nuspec
@@ -84,7 +84,7 @@
 			https://docs.microsoft.com/en-us/nuget/schema/nuspec#dependencies
 			-->
 			<group>
-				<dependency id="Xamarin.Auth" version="[1.5.0.3,)"/>
+				<dependency id="Xamarin.Auth" version="[1.6.0.4,)"/>
 				<dependency id="Xamarin.Forms" version="[2.3,)"/>
 			</group>
 			<group targetFramework="MonoAndroid10">


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes
Xamarin.Auth.XamarinForms v1.6.0.4 doesn't work with Xamarin.Auth v1.5.0.3.

This pull request increases the minimum dependency version of Xamarin.Auth to v1.6.0.4

### Checklist

- [ ] I have included examples or tests (N/A)
- [ ] I have updated the change log (N/A)
- [ ] I am listed in the CONTRIBUTORS file (N/A)
- [X] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

Update the Xamarin.Auth.XamarinForms' NuGet dependency to Xamarin.Auth v1.6.0.4