### PR TITLE
Changed UrlMatchesRedirect method to be overridable

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/WebRedirectAuthenticator.cs
@@ -187,10 +187,12 @@ namespace Xamarin.Auth._MobileServices
             return;
         }
 
-        protected bool UrlMatchesRedirect(Uri url)
+        protected virtual bool UrlMatchesRedirect(Uri url)
         {
             // mc++
             // TODO: schemas
+            
+            // Check if the scheme matches
             return url.Host == redirectUrl.Host && url.LocalPath == redirectUrl.LocalPath;
         }
 


### PR DESCRIPTION
# Xamarin.Auth Pull Request

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

I tried to inherit from `OAuth2Authenticator` to override `UrlMatchesRedirect`. I had to add the `virtual` keyword to get it working.

With this change I can do this:
```
public class CustomOAuth2Authenticator : OAuth2Authenticator
{
    protected override bool UrlMatchesRedirect(Uri url)
    {
        return true; // Use custom logic to validate
    }
}
```