### PR TITLE
Added bool to disable the http(s) scheme warning message for native UI

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -229,6 +229,13 @@ namespace Xamarin.Auth._MobileServices
         /// Method used to fetch the username of an account
         /// after it has been successfully authenticated.
         /// </param>
+        /// <param name="isUsingNativeUI"></param>
+        /// To use custom or native UI.
+        /// <param name="ignoreWarningUrlScheme">
+        /// Disable the HTTP(S)-scheme redirect URL warning.
+        /// Make sure you know what you're doing,
+        /// OAuth Data parsing might fail!
+        /// </param>
         public OAuth2Authenticator
                         (
                             string clientId,
@@ -236,11 +243,13 @@ namespace Xamarin.Auth._MobileServices
                             Uri authorizeUrl,
                             Uri redirectUrl,
                             GetUsernameAsyncFunc getUsernameAsync = null,
-                            bool isUsingNativeUI = false
+                            bool isUsingNativeUI = false,
+                            bool ignoreWarningUrlScheme = false
                         )
             : this(redirectUrl)
         {
             this.is_using_native_ui = isUsingNativeUI;
+            this.IgnoreWarningUrlScheme = ignoreWarningUrlScheme;
 
             if (string.IsNullOrEmpty(clientId))
             {
@@ -313,6 +322,13 @@ namespace Xamarin.Auth._MobileServices
         /// Method used to fetch the username of an account
         /// after it has been successfully authenticated.
         /// </param>
+        /// <param name="isUsingNativeUI"></param>
+        /// To use custom or native UI.
+        /// <param name="ignoreWarningUrlScheme">
+        /// Disable the HTTP(S)-scheme redirect URL warning.
+        /// Make sure you know what you're doing,
+        /// OAuth Data parsing might fail!
+        /// </param>
         public OAuth2Authenticator
                         (
                             string clientId,
@@ -322,11 +338,13 @@ namespace Xamarin.Auth._MobileServices
                             Uri redirectUrl,
                             Uri accessTokenUrl,
                             GetUsernameAsyncFunc getUsernameAsync = null,
-                            bool isUsingNativeUI = false
+                            bool isUsingNativeUI = false,
+                            bool ignoreWarningUrlScheme = false
                         )
-            : this(redirectUrl, clientSecret, accessTokenUrl)
+            : this(redirectUrl, clientSecret, accessTokenUrl, isUsingNativeUI)
         {
             this.is_using_native_ui = isUsingNativeUI;
+            this.IgnoreWarningUrlScheme = ignoreWarningUrlScheme;
 
             if (string.IsNullOrEmpty(clientId))
             {
@@ -388,12 +406,12 @@ namespace Xamarin.Auth._MobileServices
                 System.Diagnostics.Debug.WriteLine(this.ToString());
             }
 
-            this.clientId = clientId;                   // required
-            this.clientSecret = clientSecret;           // optional
-            this.authorizeUrl = authorizeUrl;           // required 
-            this.redirectUrl = redirectUrl;             // optional 
-            this.accessTokenUrl = accessTokenUrl;       // optional - required for Authorization Code Grant
-            this.scope = scope ?? "";                   // optional
+            this.clientId = clientId;                               // required
+            this.clientSecret = clientSecret;                       // optional
+            this.authorizeUrl = authorizeUrl;                       // required 
+            this.redirectUrl = redirectUrl;                         // optional 
+            this.accessTokenUrl = accessTokenUrl;                   // optional - required for Authorization Code Grant
+            this.scope = scope ?? "";                               // optional
 
             this.getUsernameAsync = getUsernameAsync;   // Xamarin.legacy
 
@@ -406,7 +424,7 @@ namespace Xamarin.Auth._MobileServices
                             string clientSecret = null,
                             Uri accessTokenUrl = null,
                             bool isUsingNativeUI = false
-                        )
+        )
             : base(redirectUrl, redirectUrl)
         {
             this.is_using_native_ui = isUsingNativeUI;

--- a/source/Core/Xamarin.Auth.Common.LinkSource/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/UINativeNonIntegratedBrowsers/WebAuthenticator.NativeUI.cs
@@ -41,6 +41,16 @@ namespace Xamarin.Auth._MobileServices
 
         protected bool is_using_native_ui = false;
 
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value>
+        /// <c>true</c> if disabling the HTTP(S)-scheme redirect URL; otherwise, <c>false</c>.
+        /// Make sure that you know what you're doing,
+        /// OAuth Data parsing might fail!
+        /// </value>
+        public bool IgnoreWarningUrlScheme { get; set; }
+        
         protected void ShowErrorForNativeUI(string v)
         {
             ShowErrorForNativeUIDebug(v);

--- a/source/Core/Xamarin.Auth.XamarinIOS/WebAuthenticator.XamarinIOS.cs
+++ b/source/Core/Xamarin.Auth.XamarinIOS/WebAuthenticator.XamarinIOS.cs
@@ -62,7 +62,7 @@ namespace Xamarin.Auth._MobileServices
                 {
                     Uri redirect_uri = new Uri(query_parts["redirect_uri"]);
                     string scheme = redirect_uri.Scheme;
-                    if (scheme.StartsWith("http", StringComparison.InvariantCultureIgnoreCase))
+                    if (scheme.StartsWith("http", StringComparison.InvariantCultureIgnoreCase) && !IgnoreWarningUrlScheme)
                     {
                         StringBuilder sb = new StringBuilder();
                         sb.AppendLine("WARNING");
@@ -70,7 +70,7 @@ namespace Xamarin.Auth._MobileServices
                         sb.AppendLine($"Native UI used with http[s] schema!");
                         sb.AppendLine($"Redirect URL will be loaded in Native UI!");
                         sb.AppendLine($"OAuth Data parsing might fail!");
-
+                        
                         ShowErrorForNativeUI(sb.ToString());
                     }
                 }


### PR DESCRIPTION
# Xamarin.Auth Pull Request

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
Option to disable the warning pop-up when you use a http(s) scheme redirect url. Perhaps this might seem weird, but my endpoint is using Lavaral Password, which doesn't accept custom url scheme. 

When this message is disabled, I can use solutation one (http redirect) from this [page](https://github.com/OAuthSwift/OAuthSwift/wiki/API-with-only-HTTP-scheme-into-callback-URL).