### PR TITLE
Added the functionality to allow the caller to supply HTTP headers when making an access token request

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -868,11 +868,39 @@ namespace Xamarin.Auth._MobileServices
         /// <returns>The data provided in the response to the access token request.</returns>
         public async Task<IDictionary<string, string>> RequestAccessTokenAsync(IDictionary<string, string> queryValues)
         {
+            return await this.RequestAccessTokenAsync(queryValues, null);
+        }
+
+        /// <summary>
+        /// Asynchronously makes a request to the access token URL with the given parameters.
+        /// </summary>
+        /// <param name="queryValues">The parameters to make the request with.</param>
+        /// <param name="httpHeaders">The HTTP headers to add to the request.</param>
+        /// <returns>The data provided in the response to the access token request.</returns>
+        public async Task<IDictionary<string, string>> RequestAccessTokenAsync(IDictionary<string, string> queryValues, IDictionary<string, IList<string>> httpHeaders)
+        {
             // mc++ changed protected to public for extension methods RefreshToken (Adrian Stevens) 
             var content = new FormUrlEncodedContent(queryValues);
 
-
             HttpClient client = new HttpClient();
+
+            client.DefaultRequestHeaders.Clear();
+            
+            try
+            {
+                if (httpHeaders != null)
+                {
+                    foreach (var httpHeader in httpHeaders)
+                    {
+                        client.DefaultRequestHeaders.Add(httpHeader.Key, httpHeader.Value);
+                    }
+                }
+            }
+            catch (Exception e)
+            {
+                throw new Exception("Unable to add HTTP header", e);
+            }
+
             HttpResponseMessage response = await client.PostAsync(accessTokenUrl, content).ConfigureAwait(false);
             string text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
# Xamarin.Auth Pull Request

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- added the functionality to allow the caller to supply HTTP headers when making an access token request