### PR TITLE
Dont include client secret in URL

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -853,10 +853,6 @@ namespace Xamarin.Auth._MobileServices
                 { "redirect_uri", redirectUrl.AbsoluteUri },
                 { "client_id", clientId },
             };
-            if (!string.IsNullOrEmpty(clientSecret))
-            {
-                queryValues["client_secret"] = clientSecret;
-            }
 
             return RequestAccessTokenAsync(queryValues);
         }
@@ -873,6 +869,13 @@ namespace Xamarin.Auth._MobileServices
 
 
             HttpClient client = new HttpClient();
+
+            //If client secret is set, use HTTP BASIC auth to authenticate to the token endpoint
+            if (!string.IsNullOrEmpty(this.ClientSecret))
+            {
+                client.DefaultRequestHeaders.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("basic", Convert.ToBase64String(UTF8Encoding.UTF8.GetBytes($"{this.ClientId}:{this.ClientSecret}")));
+            }
+
             HttpResponseMessage response = await client.PostAsync(accessTokenUrl, content).ConfigureAwait(false);
             string text = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
 


### PR DESCRIPTION
Authenticate using HTTP BASIC auth instead

# Xamarin.Auth Pull Request

Fixes #261  (At least for people using identity server 4)

### Checklist

- [ ] I have included examples or tests - Cannot find a test project covering this
- [ ] I have updated the change log - cannot find a changelog file
- [ ] I am listed in the CONTRIBUTORS file - cannot find CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
- In code flow, when exchanging the code for a token at the token endoint, correctly authenticate to the IdP using HTTP BASIC auth, and do not send the client_secret as plaintext in the URL. (Follows RFC)

