### PR TITLE
Fix OnPageLoading and OnPageLoaded functions are not called from WKWe…

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.WKWebView.WKWebViewNavigationDelegate.cs
+++ b/source/Core/Xamarin.Auth.XamarinIOS/PlatformSpecific/WebAuthenticatorController.WKWebView.WKWebViewNavigationDelegate.cs
@@ -83,6 +83,7 @@ namespace Xamarin.Auth._MobileServices
         internal class WKWebViewNavigationDelegate : WebKit.WKNavigationDelegate
         {
             WebAuthenticatorController controller = null;
+            Uri lastUrl;
 
             public WKWebViewNavigationDelegate(WebAuthenticatorController c)
             {
@@ -219,8 +220,11 @@ namespace Xamarin.Auth._MobileServices
                 sb.AppendLine($"WKWebViewNavigationDelegate.DidStartProvisionalNavigation ");
                 sb.AppendLine($"        webView.Url.AbsoluteString = {webView.Url.AbsoluteString}");
                 System.Diagnostics.Debug.WriteLine(sb.ToString());
-                #endif
-
+#endif
+                if (!controller.authenticator.HasCompleted)
+                {
+                    controller.authenticator.OnPageLoading(new Uri(webView.Url.AbsoluteString));
+                }
                 return;
             }
 
@@ -237,8 +241,14 @@ namespace Xamarin.Auth._MobileServices
                 sb.AppendLine($"WKWebViewNavigationDelegate.DidFinishNavigation ");
                 sb.AppendLine($"        webView.Url.AbsoluteString = {webView.Url.AbsoluteString}");
                 System.Diagnostics.Debug.WriteLine(sb.ToString());
-                #endif
+#endif
 
+                var url = new Uri(webView.Url.AbsoluteString);
+                if (url != lastUrl && !controller.authenticator.HasCompleted)
+                {
+                    lastUrl = url;
+                    controller.authenticator.OnPageLoaded(url);
+                }
                 return;
             }
 


### PR DESCRIPTION
…bViewUIDelegate

# Xamarin.Auth Pull Request

Fixes 1.

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

- WebAuthenticator.OnPageLoading method is called from DidStartProvisionalNavigation
- WebAuthenticator.OnPageLoaded method is called from DidFinishNavigation

