### PR TITLE
Used OriginalString to avoid adding trailing slash

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth2Authenticator.cs
@@ -850,7 +850,7 @@ namespace Xamarin.Auth._MobileServices
             {
                 { "grant_type", "authorization_code" },
                 { "code", code },
-                { "redirect_uri", redirectUrl.AbsoluteUri },
+                { "redirect_uri", redirectUrl.OriginalString }, //to avoid adding trailing slash
                 { "client_id", clientId },
             };
             if (!string.IsNullOrEmpty(clientSecret))
@@ -881,6 +881,7 @@ namespace Xamarin.Auth._MobileServices
 
             if (data.ContainsKey("error"))
             {
+                System.Diagnostics.Debug.WriteLine($"RequestAccessTokenAsync exception {text}");//log actual response from server
                 throw new AuthException("Error authenticating: " + data["error"]);
             }
             #region


### PR DESCRIPTION
The OAuthserver is rejecting our accesstokenrequest as `AbsoluteUri` is being used which is adding a trailing slash and logging actual response from the server for debugging purpose.

# Xamarin.Auth Pull Request

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [x] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-Use OriginalString always to send the same redirect_uri parameter to oAuth Server.
-Log the actual response from the server. the error `invalid_grant` is not helping debug the issue.
-
