### PR TITLE
OAuth1 - add optional parameter to put oauth parameters in header instead of query string

### DIFF
--- a/nuget/Xamarin.Auth.nuspec
+++ b/nuget/Xamarin.Auth.nuspec
@@ -5,20 +5,20 @@
     -->
     <metadata minClientVersion="2.8.1">
         <id>
-            Xamarin.Auth
+            Onyx.Xamarin.Auth
         </id>
         <title>
-            Xamarin.Auth
+            Onyx.Xamarin.Auth
         </title>
 		<authors>
-			Microsoft
+			Onyx Software Limited
 		</authors>
 		<owners>
-			Microsoft
+            Onyx Software Limited
 		</owners>
 		<copyright>
-			© Microsoft Corporation. All rights reserved.
-		</copyright>
+            © Onyx Software Limited. All rights reserved.
+        </copyright>
         <!--
         SemVer - Semantic Versioning
         http://semver.org/
@@ -27,9 +27,7 @@
 			1.7.0.0
         </version>
 		<releaseNotes>
-            - FindAccountsForService throws on iOS #370
-            - updates to stale projects (dependencies, targets)
-            - removed unsupported platforms (Windows Phone, Windows 8.x)
+            Onyx enhancement of Xamarin.Auth version 1.7.0
 		</releaseNotes>
         <licenseUrl>
             https://go.microsoft.com/fwlink/?linkid=2021795
@@ -123,7 +121,7 @@
         <!--
             Core - Portable
         -->
-        <file
+        <!--<file
             src="..\source\Core\Xamarin.Auth.Portable\bin\Release\Xamarin.Auth.dll"
             target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+XamarinIOS10/Xamarin.Auth.dll"
             >
@@ -132,7 +130,7 @@
             src="..\source\Core\Xamarin.Auth.Portable\bin\Release\Xamarin.Auth.pdb"
             target="lib/portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+XamarinIOS10/Xamarin.Auth.pdb"
             >
-        </file>
+        </file>-->
 
         <!--
             Xamarin.Android
@@ -281,7 +279,7 @@
             │   ├── Xamarin.Auth.pdb
             │   └── Xamarin.Auth.pri
         -->
-        <file
+        <!--<file
             src="..\source\Core\Xamarin.Auth.UniversalWindowsPlatform\bin\Release\Xamarin.Auth.dll"
             target="lib/uap10.0/Xamarin.Auth.dll"
             >
@@ -295,7 +293,7 @@
             src="..\source\Core\Xamarin.Auth.UniversalWindowsPlatform\bin\Release\Xamarin.Auth.pri"
             target="lib/uap10.0/Xamarin.Auth.pri"
             >
-        </file>
+        </file>-->
         <!--
         mc++ 2017-10-17 output changed??
         <file
@@ -304,7 +302,7 @@
             >
         </file>
         -->		
-        <file
+        <!--<file
             src="..\source\Core\Xamarin.Auth.UniversalWindowsPlatform\bin\Release\WebAuthenticatorPage.xbf"
             target="lib/uap10.0/Xamarin.Auth/WebAuthenticatorPage.xbf"
             >
@@ -313,7 +311,7 @@
             src="..\source\Core\Xamarin.Auth.UniversalWindowsPlatform\bin\Release\Xamarin.Auth.xr.xml"
             target="lib/uap10.0/Xamarin.Auth/Xamarin.Auth.xr.xml"
             >
-        </file>
+        </file>-->
 
     </files>
 </package>

--- a/source/Core/Xamarin.Auth.Common.LinkSource/OAuth1Authenticator.cs
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/OAuth1Authenticator.cs
@@ -68,7 +68,8 @@ namespace Xamarin.Auth._MobileServices
         string tokenSecret;
 
         string verifier;
-
+        bool useHeaderForOAuthParameters;
+        
         /// <summary>
         /// Initializes a new instance of the <see cref="Xamarin.Auth.OAuth1Authenticator"/> class.
         /// </summary>
@@ -103,7 +104,8 @@ namespace Xamarin.Auth._MobileServices
                             Uri accessTokenUrl, 
                             Uri callbackUrl,
                             GetUsernameAsyncFunc getUsernameAsync = null,
-                            bool isUsingNativeUI = false
+                            bool isUsingNativeUI = false,
+                            bool useHeaderForOAuthParameters = false
                         )
             : base(authorizeUrl, callbackUrl)
         {
@@ -149,11 +151,14 @@ namespace Xamarin.Auth._MobileServices
 
             this.HttpWebClientFrameworkType = Auth.HttpWebClientFrameworkType.WebRequest;
 
+            this.useHeaderForOAuthParameters = useHeaderForOAuthParameters;
+
             #if DEBUG
             StringBuilder sb = new StringBuilder();
             sb.AppendLine($"OAuth1Authenticator ");
             sb.AppendLine($"        IsUsingNativeUI = {IsUsingNativeUI}");
             sb.AppendLine($"        callbackUrl = {callbackUrl}");
+            sb.AppendLine($"        useHeaderForOAuthParameters = {useHeaderForOAuthParameters}");
             System.Diagnostics.Debug.WriteLine(sb.ToString());
             #endif
 
@@ -208,7 +213,8 @@ namespace Xamarin.Auth._MobileServices
                                 },
                                 consumerKey,
                                 consumerSecret,
-                                ""
+                                "",
+                                useHeaderForOAuthParameters
                            );
 
             if (this.HttpWebClientFrameworkType == HttpWebClientFrameworkType.WebRequest)
@@ -326,7 +332,8 @@ namespace Xamarin.Auth._MobileServices
                                                 request_parameters,
                                                 consumerKey,
                                                 consumerSecret,
-                                                tokenSecret
+                                                tokenSecret,
+                                                useHeaderForOAuthParameters
                                             );
 
             if (this.HttpWebClientFrameworkType == HttpWebClientFrameworkType.WebRequest)


### PR DESCRIPTION
# Xamarin.Auth Pull Request

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:
This is a patch to v1.7.0 and was based on the 1.7.0 tag.
I use the Xamarin.Auth library against www.trademe.co.nz. They still use OAuth1, and recently improved security by forcing the oauth_ parameters to be provided in the header instead of the query string.

This change provides an optional parameter (default to false, or existing behaviour) which a dev can use to ensure oauth_ parameters are placed in the header instead of the query string.
