### PR TITLE
Update CustomTabsConfiguration.cs

### DIFF
--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
@@ -466,7 +466,7 @@ namespace Xamarin.Auth
                                                        activity.ApplicationContext,
                                                        actionSourceId,
                                                        actionIntent,
-                                                       0
+                                                       PendingIntentFlags.Immutable
                                                     );
             return broadcast;
         }


### PR DESCRIPTION
need the pending intent flag set to Immutable for Android 12 and above.

# Xamarin.Auth Pull Request

Fixes # .

### Checklist

- [ ] I have included examples or tests
- [ ] I have updated the change log
- [ ] I am listed in the CONTRIBUTORS file
- [ ] I have cleaned up the commit history (use rebase and squash)

### Changes proposed in this pull request:

-
-
-
