### PR TITLE
#322, the previous implementation won't work if chrome is disabled, t…

### DIFF
--- a/source/Core/Xamarin.Auth.Common.LinkSource/Xamarin.Auth.Common.LinkSource.csproj
+++ b/source/Core/Xamarin.Auth.Common.LinkSource/Xamarin.Auth.Common.LinkSource.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project ToolsVersion="12.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -9,12 +9,13 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Xamarin.Auth</RootNamespace>
     <AssemblyName>Xamarin.Auth</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SolutionDir Condition="$(SolutionDir) == '' Or $(SolutionDir) == '*Undefined*'">..\</SolutionDir>
     <RestorePackages>true</RestorePackages>
     <XamarinAuthCustomPreprocessorConstantsDefines>
     </XamarinAuthCustomPreprocessorConstantsDefines>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
@@ -464,7 +464,7 @@ namespace Xamarin.Auth
                                                        activity.ApplicationContext,
                                                        actionSourceId,
                                                        actionIntent,
-                                                       0
+                                                       PendingIntentFlags.CancelCurrent | PendingIntentFlags.Immutable
                                                     );
             return broadcast;
         }

--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsConfiguration.cs
@@ -55,13 +55,11 @@ namespace Xamarin.Auth
                                                                    "http://xamarin.com"
                                                                 );
             PackagesSupportingCustomTabs = PackageManagerHelper.PackagesSupportingCustomTabs;
-            PackageForCustomTabs = PackagesSupportingCustomTabs.FirstOrDefault().Value;
+            PackageForCustomTabs = PackagesSupportingCustomTabs.FirstOrDefault();
 
             CustomTabsActivityManager = new CustomTabsActivityManager(a);
             CustomTabsIntentBuilder = new CustomTabsIntent.Builder(CustomTabsActivityManager.Session);
             CustomTabActivityHelper = new CustomTabActivityHelper();
-
-            return;
         }
 
         static global::Android.App.Activity activity = null;
@@ -76,7 +74,7 @@ namespace Xamarin.Auth
             set;
         }
 
-		public static Dictionary<string, string> PackagesSupportingCustomTabs
+		public static List<string> PackagesSupportingCustomTabs
 		{
 			get;
 			set;

--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/PackageManagerHelper.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/PackageManagerHelper.cs
@@ -24,7 +24,7 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
         {
             get;
             set;
-        }
+        } = new List<string>();
 
         public static string CustomTabsExtraKeepAlive
         {
@@ -162,7 +162,7 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
                 PackagesSupportingCustomTabs.Add(package);
             }
 
-            sPackageNameToUse = sPackageNamesToUse.FirstOrDefault();
+            sPackageNameToUse = sPackageNamesToUse.LastOrDefault();
             return sPackageNamesToUse;
         }
 

--- a/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/PackageManagerHelper.cs
+++ b/source/Core/Xamarin.Auth.XamarinAndroid/UINativeNonIntegratedBrowsers/CustomTabsUtilities/PackageManagerHelper.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Text;
 
 using Android.Content;
@@ -19,24 +20,11 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
     public class PackageManagerHelper
 	#endif
     {
-        /*
-        internal const string STABLE_PACKAGE = "com.android.chrome";
-        internal const string BETA_PACKAGE = "com.chrome.beta";
-        internal const string DEV_PACKAGE = "com.chrome.dev";
-        internal const string LOCAL_PACKAGE = "com.google.android.apps.chrome";
-        */
-        public static Dictionary<string, string> PackagesSupportingCustomTabs
+        public static List<string> PackagesSupportingCustomTabs
         {
             get;
             set;
-        } =
-            new Dictionary<string, string>()
-            {
-                {"STABLE_PACKAGE", "com.android.chrome"},
-                {"BETA_PACKAGE", "com.chrome.beta"},
-                {"DEV_PACKAGE", "com.chrome.dev"},
-                {"LOCAL_PACKAGE", "com.google.android.apps.chrome"},
-            };
+        }
 
         public static string CustomTabsExtraKeepAlive
         {
@@ -117,7 +105,7 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
             #if DEBUG
             StringBuilder sb1 = new StringBuilder();
             sb1.AppendLine($"      package for url ");
-            sb1.AppendLine($"         url = {url.ToString()}");
+            sb1.AppendLine($"         url = {url}");
 			sb1.AppendLine($"         resolve_info_default_view_handler.ResolvePackageName       = {resolve_info_default_view_handler.ResolvePackageName}");
 			sb1.AppendLine($"         resolve_info_default_view_handler.ActivityInfo.PackageName = {resolve_info_default_view_handler.ActivityInfo.PackageName}");
 			sb1.AppendLine($"         resolve_info_default_view_handler.ActivityInfo.Name        = {resolve_info_default_view_handler.ActivityInfo.Name}");
@@ -163,56 +151,18 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
 
             // Now packagesSupportingCustomTabs contains all apps that can handle both VIEW intents
             // and service calls.
-            if (packagesSupportingCustomTabs.Count == 0)
+
+            foreach (var package in packagesSupportingCustomTabs)
             {
-                System.Diagnostics.Debug.WriteLine($" Packages Supporting CustomTabs Count = 0");
-                sPackageNameToUse = null;
-            }
-            else if (packagesSupportingCustomTabs.Count == 1)
-            {
-                System.Diagnostics.Debug.WriteLine($" Packages Supporting CustomTabs Count = 1");
-                System.Diagnostics.Debug.WriteLine($" Packages Supporting CustomTabs = {packagesSupportingCustomTabs[0]}");
-                sPackageNameToUse = packagesSupportingCustomTabs[0];
-                sPackageNamesToUse.Add(sPackageNameToUse);
-            }
-            else if
-                (
-                    // !TextUtils.IsEmpty(defaultViewHandlerPackageName)    // Android API
-                    string.IsNullOrEmpty(defaultViewHandlerPackageName)     // .NET API
-                    &&
-                    !HasSpecializedHandlerIntents(context, activityIntent)
-                    &&
-                    packagesSupportingCustomTabs.Contains(defaultViewHandlerPackageName)
-                )
-            {
-                sPackageNameToUse = defaultViewHandlerPackageName;
-            }
-            else if (packagesSupportingCustomTabs.Contains(PackagesSupportingCustomTabs["STABLE_PACKAGE"]))
-            {
-                sPackageNameToUse = PackagesSupportingCustomTabs["STABLE_PACKAGE"];
-            }
-            else if (packagesSupportingCustomTabs.Contains(PackagesSupportingCustomTabs["BETA_PACKAGE"]))
-            {
-                sPackageNameToUse = PackagesSupportingCustomTabs["BETA_PACKAGE"];
-            }
-            else if (packagesSupportingCustomTabs.Contains(PackagesSupportingCustomTabs["DEV_PACKAGE"]))
-            {
-                sPackageNameToUse = PackagesSupportingCustomTabs["DEV_PACKAGE"];
-            }
-            else if (packagesSupportingCustomTabs.Contains(PackagesSupportingCustomTabs["CANARY_PACKAGE"]))
-            {
-                sPackageNameToUse = PackagesSupportingCustomTabs["CANARY_PACKAGE"];
-            }
-            else if (packagesSupportingCustomTabs.Contains(PackagesSupportingCustomTabs["LOCAL_PACKAGE"]))
-            {
-                sPackageNameToUse = PackagesSupportingCustomTabs["LOCAL_PACKAGE"];
+                if (string.IsNullOrEmpty(package) || PackagesSupportingCustomTabs.Contains(package))
+                {
+                    continue;
+                }
+                sPackageNamesToUse.Add(package);
+                PackagesSupportingCustomTabs.Add(package);
             }
 
-            for (int i = 0; i < sPackageNamesToUse.Count; i++)
-            {
-                PackagesSupportingCustomTabs.Add($"Detected {i}", sPackageNamesToUse[i]);
-            }
-
+            sPackageNameToUse = sPackageNamesToUse.FirstOrDefault();
             return sPackageNamesToUse;
         }
 
@@ -265,20 +215,6 @@ namespace Android.Support.CustomTabs.Chromium.SharedUtilities._MobileServices
 
 
         /// <returns> All possible chrome package names that provide custom tabs feature. </returns>
-        public static string[] Packages
-        {
-            get
-            {
-                return new string[]
-                {
-                    "",
-                    PackagesSupportingCustomTabs["STABLE_PACKAGE"],
-                    PackagesSupportingCustomTabs["BETA_PACKAGE"],
-                    PackagesSupportingCustomTabs["DEV_PACKAGE"],
-                    PackagesSupportingCustomTabs["CANARY_PACKAGE"],
-                    PackagesSupportingCustomTabs["LOCAL_PACKAGE"],
-                };
-            }
-        }
+        public static string[] Packages => PackagesSupportingCustomTabs.ToArray();
     }
 }

--- a/source/Extensions/Xamarin.Auth.Extensions.LinkSource/Xamarin.Auth.Extensions.LinkSource.csproj
+++ b/source/Extensions/Xamarin.Auth.Extensions.LinkSource/Xamarin.Auth.Extensions.LinkSource.csproj
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+<Project DefaultTargets="Build" ToolsVersion="12.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -7,11 +7,12 @@
     <OutputType>Library</OutputType>
     <RootNamespace>Xamarin.Auth</RootNamespace>
     <AssemblyName>Xamarin.Auth.Extensions</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <XamarinAuthCustomPreprocessorConstantsDefines>
     </XamarinAuthCustomPreprocessorConstantsDefines>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -73,10 +74,7 @@
   http://laurentkempe.com/2009/12/03/ProjectReference-with-Condition-in-your-MSBuild-project-files/
   msbuild Choose When ProjectReference Reference Include
   -->
-  <ItemGroup>
-    <Folder Include="AccountStore\" />
-    <Folder Include="AccountStore\CryptoAccountManager\" />
-  </ItemGroup>
+  <ItemGroup />
   <Choose>
     <When Condition="! exists('..\..\Core\Xamarin.Auth.Common.LinkSource\Xamarin.Auth.Common.LinkSource.csproj')">
       <!-- nuget packages (dll) refs -->
@@ -102,7 +100,7 @@
   ==================================================================================================
   -->
   <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
-    <!--
+  <!--
   <Import Project="..\..\packages\Microsoft.DotNet.BuildTools.GenAPI.1.0.0-beta-00081\build\Microsoft.DotNet.BuildTools.GenAPI.targets" Condition="Exists('..\..\packages\Microsoft.DotNet.BuildTools.GenAPI.1.0.0-beta-00081\build\Microsoft.DotNet.BuildTools.GenAPI.targets')" />
     -->
 </Project>


### PR DESCRIPTION
There is no way to be sure that com.chrome.beta or com.chrome.dev is installed. Better to fetch the packages on runtime.

# Xamarin.Auth Pull Request

Fixes #322  .
